### PR TITLE
Add cross-platform installer scripts

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -1,0 +1,250 @@
+#
+# Docuchango Installer for Windows
+# Install docuchango documentation validation framework
+#
+# Usage:
+#   irm https://raw.githubusercontent.com/jrepp/docuchango/main/install.ps1 | iex
+#   Or locally: .\install.ps1
+#
+
+$ErrorActionPreference = "Stop"
+
+# Configuration
+$PYTHON_MIN_VERSION = "3.10"
+$INSTALL_METHOD = "pip"
+
+function Print-Header {
+    Write-Host ""
+    Write-Host "╔════════════════════════════════════════╗" -ForegroundColor Blue
+    Write-Host "║     Docuchango Installer v0.1.0      ║" -ForegroundColor Blue
+    Write-Host "╚════════════════════════════════════════╝" -ForegroundColor Blue
+    Write-Host ""
+}
+
+function Print-Step {
+    param($Message)
+    Write-Host "▸ $Message" -ForegroundColor Blue
+}
+
+function Print-Success {
+    param($Message)
+    Write-Host "✓ $Message" -ForegroundColor Green
+}
+
+function Print-Error {
+    param($Message)
+    Write-Host "✗ $Message" -ForegroundColor Red
+}
+
+function Print-Warning {
+    param($Message)
+    Write-Host "⚠ $Message" -ForegroundColor Yellow
+}
+
+function Check-Python {
+    Print-Step "Checking Python installation..."
+
+    $pythonCmd = Get-Command python -ErrorAction SilentlyContinue
+    if (-not $pythonCmd) {
+        $pythonCmd = Get-Command python3 -ErrorAction SilentlyContinue
+    }
+
+    if (-not $pythonCmd) {
+        Print-Error "Python 3 is not installed"
+        Write-Host "Please install Python $PYTHON_MIN_VERSION or higher from https://www.python.org/"
+        exit 1
+    }
+
+    $pythonExe = $pythonCmd.Source
+    $pythonVersion = & $pythonExe -c "import sys; print('.'.join(map(str, sys.version_info[:2])))"
+    Print-Success "Found Python $pythonVersion"
+
+    # Check version
+    $requiredParts = $PYTHON_MIN_VERSION.Split('.')
+    $currentParts = $pythonVersion.Split('.')
+
+    $requiredMajor = [int]$requiredParts[0]
+    $requiredMinor = [int]$requiredParts[1]
+    $currentMajor = [int]$currentParts[0]
+    $currentMinor = [int]$currentParts[1]
+
+    if (($currentMajor -lt $requiredMajor) -or (($currentMajor -eq $requiredMajor) -and ($currentMinor -lt $requiredMinor))) {
+        Print-Error "Python $PYTHON_MIN_VERSION or higher is required (found $pythonVersion)"
+        exit 1
+    }
+
+    return $pythonExe
+}
+
+function Check-Pip {
+    param($PythonExe)
+
+    Print-Step "Checking pip installation..."
+
+    $pipCheck = & $PythonExe -m pip --version 2>&1
+    if ($LASTEXITCODE -ne 0) {
+        Print-Error "pip is not installed"
+        Write-Host "Installing pip..."
+
+        & $PythonExe -m ensurepip --upgrade
+        if ($LASTEXITCODE -ne 0) {
+            Print-Error "Failed to install pip"
+            Write-Host "Please install pip manually: https://pip.pypa.io/en/stable/installation/"
+            exit 1
+        }
+    }
+
+    Print-Success "pip is available"
+}
+
+function Check-Uv {
+    Print-Step "Checking for uv (optional, faster installer)..."
+
+    $uvCmd = Get-Command uv -ErrorAction SilentlyContinue
+    if ($uvCmd) {
+        $uvVersion = & uv --version 2>&1 | Select-String -Pattern "uv (\d+\.\d+\.\d+)" | ForEach-Object { $_.Matches.Groups[1].Value }
+        Print-Success "Found uv $uvVersion"
+        return "uv"
+    }
+    else {
+        Print-Warning "uv not found (optional). Will use pip for installation."
+        Write-Host "          To install uv later: irm https://astral.sh/uv/install.ps1 | iex"
+        return "pip"
+    }
+}
+
+function Install-Docuchango {
+    param($PythonExe, $InstallMethod)
+
+    Print-Step "Installing docuchango..."
+
+    if ($InstallMethod -eq "uv") {
+        Write-Host "Using uv for faster installation..."
+
+        if (Test-Path ".git") {
+            # Local development install
+            & uv pip install -e .
+        }
+        else {
+            # Install from PyPI
+            & uv pip install docuchango
+        }
+
+        if ($LASTEXITCODE -ne 0) {
+            Print-Error "Installation failed with uv"
+            exit 1
+        }
+    }
+    else {
+        Write-Host "Using pip for installation..."
+
+        if (Test-Path ".git") {
+            # Local development install
+            & $PythonExe -m pip install -e .
+        }
+        else {
+            # Install from PyPI
+            & $PythonExe -m pip install docuchango
+        }
+
+        if ($LASTEXITCODE -ne 0) {
+            Print-Error "Installation failed with pip"
+            exit 1
+        }
+    }
+
+    Print-Success "docuchango installed successfully"
+}
+
+function Verify-Installation {
+    Print-Step "Verifying installation..."
+
+    $docuchangoCmd = Get-Command docuchango -ErrorAction SilentlyContinue
+    if (-not $docuchangoCmd) {
+        Print-Warning "docuchango command not found in PATH"
+        Write-Host ""
+        Write-Host "You may need to add Python's Scripts directory to your PATH."
+        Write-Host "Common locations:"
+        Write-Host "  - C:\Users\$env:USERNAME\AppData\Local\Programs\Python\Python3XX\Scripts"
+        Write-Host "  - C:\Users\$env:USERNAME\AppData\Roaming\Python\Python3XX\Scripts"
+        Write-Host ""
+        Write-Host "To add to PATH, run PowerShell as Administrator:"
+        Write-Host '  $env:PATH += ";C:\Path\To\Python\Scripts"'
+        Write-Host '  [System.Environment]::SetEnvironmentVariable("PATH", $env:PATH, [System.EnvironmentVariableTarget]::User)'
+        Write-Host ""
+        return $false
+    }
+
+    # Test the command
+    $version = & docuchango --version 2>&1
+    Print-Success "docuchango is available: $version"
+
+    # Test help command
+    & docuchango --help | Out-Null
+    if ($LASTEXITCODE -eq 0) {
+        Print-Success "docuchango commands are working"
+    }
+    else {
+        Print-Warning "docuchango command exists but help failed"
+        return $false
+    }
+
+    return $true
+}
+
+function Show-NextSteps {
+    Write-Host ""
+    Write-Host "═══════════════════════════════════════════════" -ForegroundColor Green
+    Write-Host "  Installation Complete!" -ForegroundColor Green
+    Write-Host "═══════════════════════════════════════════════" -ForegroundColor Green
+    Write-Host ""
+    Write-Host "Next steps:"
+    Write-Host ""
+    Write-Host "1. View the bootstrap guide:"
+    Write-Host "   docuchango bootstrap" -ForegroundColor Blue
+    Write-Host ""
+    Write-Host "2. View agent instructions:"
+    Write-Host "   docuchango bootstrap --guide agent" -ForegroundColor Blue
+    Write-Host ""
+    Write-Host "3. Validate your documentation:"
+    Write-Host "   cd your-project" -ForegroundColor Blue
+    Write-Host "   docuchango validate" -ForegroundColor Blue
+    Write-Host ""
+    Write-Host "4. Get help:"
+    Write-Host "   docuchango --help" -ForegroundColor Blue
+    Write-Host ""
+    Write-Host "For more information, visit:"
+    Write-Host "  https://github.com/jrepp/docuchango"
+    Write-Host ""
+}
+
+function Main {
+    Print-Header
+
+    $pythonExe = Check-Python
+    Check-Pip $pythonExe
+    $installMethod = Check-Uv
+
+    Write-Host ""
+    Install-Docuchango $pythonExe $installMethod
+
+    Write-Host ""
+    $verified = Verify-Installation
+
+    if ($verified) {
+        Show-NextSteps
+    }
+    else {
+        Write-Host ""
+        Print-Warning "Installation completed but verification had issues"
+        Write-Host "Try running: docuchango --version"
+        Write-Host ""
+        Write-Host "If the command is not found, you may need to:"
+        Write-Host "1. Restart your PowerShell"
+        Write-Host "2. Add Python's Scripts directory to your PATH"
+        Write-Host ""
+    }
+}
+
+# Run main installation
+Main

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,227 @@
+#!/bin/bash
+#
+# Docuchango Installer
+# Install docuchango documentation validation framework
+#
+# Usage:
+#   curl -sSL https://raw.githubusercontent.com/jrepp/docuchango/main/install.sh | bash
+#   Or locally: ./install.sh
+#
+
+set -e
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+# Configuration
+PYTHON_MIN_VERSION="3.10"
+INSTALL_METHOD="pip"  # or "uv"
+
+print_header() {
+    echo ""
+    echo -e "${BLUE}╔════════════════════════════════════════╗${NC}"
+    echo -e "${BLUE}║${NC}     Docuchango Installer v0.1.0      ${BLUE}║${NC}"
+    echo -e "${BLUE}╚════════════════════════════════════════╝${NC}"
+    echo ""
+}
+
+print_step() {
+    echo -e "${BLUE}▸${NC} $1"
+}
+
+print_success() {
+    echo -e "${GREEN}✓${NC} $1"
+}
+
+print_error() {
+    echo -e "${RED}✗${NC} $1"
+}
+
+print_warning() {
+    echo -e "${YELLOW}⚠${NC} $1"
+}
+
+check_python() {
+    print_step "Checking Python installation..."
+
+    if ! command -v python3 &> /dev/null; then
+        print_error "Python 3 is not installed"
+        echo "Please install Python ${PYTHON_MIN_VERSION} or higher from https://www.python.org/"
+        exit 1
+    fi
+
+    PYTHON_VERSION=$(python3 -c 'import sys; print(".".join(map(str, sys.version_info[:2])))')
+    print_success "Found Python ${PYTHON_VERSION}"
+
+    # Check version
+    REQUIRED_VERSION=$(echo "$PYTHON_MIN_VERSION" | awk -F. '{printf "%d%02d", $1, $2}')
+    CURRENT_VERSION=$(echo "$PYTHON_VERSION" | awk -F. '{printf "%d%02d", $1, $2}')
+
+    if [ "$CURRENT_VERSION" -lt "$REQUIRED_VERSION" ]; then
+        print_error "Python ${PYTHON_MIN_VERSION} or higher is required (found ${PYTHON_VERSION})"
+        exit 1
+    fi
+}
+
+check_pip() {
+    print_step "Checking pip installation..."
+
+    if ! python3 -m pip --version &> /dev/null; then
+        print_error "pip is not installed"
+        echo "Installing pip..."
+        python3 -m ensurepip --upgrade || {
+            print_error "Failed to install pip"
+            echo "Please install pip manually: https://pip.pypa.io/en/stable/installation/"
+            exit 1
+        }
+    fi
+
+    print_success "pip is available"
+}
+
+check_uv() {
+    print_step "Checking for uv (optional, faster installer)..."
+
+    if command -v uv &> /dev/null; then
+        UV_VERSION=$(uv --version | awk '{print $2}')
+        print_success "Found uv ${UV_VERSION}"
+        INSTALL_METHOD="uv"
+    else
+        print_warning "uv not found (optional). Will use pip for installation."
+        echo "          To install uv later: curl -LsSf https://astral.sh/uv/install.sh | sh"
+    fi
+}
+
+install_docuchango() {
+    print_step "Installing docuchango..."
+
+    if [ "$INSTALL_METHOD" = "uv" ]; then
+        echo "Using uv for faster installation..."
+        if [ -d ".git" ]; then
+            # Local development install
+            uv pip install -e . || {
+                print_error "Installation failed with uv"
+                exit 1
+            }
+        else
+            # Install from PyPI
+            uv pip install docuchango || {
+                print_error "Installation failed with uv"
+                exit 1
+            }
+        fi
+    else
+        echo "Using pip for installation..."
+        if [ -d ".git" ]; then
+            # Local development install
+            python3 -m pip install -e . || {
+                print_error "Installation failed with pip"
+                exit 1
+            }
+        else
+            # Install from PyPI
+            python3 -m pip install docuchango || {
+                print_error "Installation failed with pip"
+                exit 1
+            }
+        fi
+    fi
+
+    print_success "docuchango installed successfully"
+}
+
+verify_installation() {
+    print_step "Verifying installation..."
+
+    if ! command -v docuchango &> /dev/null; then
+        print_warning "docuchango command not found in PATH"
+        echo ""
+        echo "You may need to add the following to your PATH:"
+
+        if [ -d "$HOME/.local/bin" ]; then
+            echo "  export PATH=\"\$HOME/.local/bin:\$PATH\""
+        fi
+
+        if python3 -c "import site; print(site.USER_BASE)" &> /dev/null; then
+            USER_BASE=$(python3 -c "import site; print(site.USER_BASE)")
+            echo "  export PATH=\"${USER_BASE}/bin:\$PATH\""
+        fi
+
+        echo ""
+        echo "Add this to your ~/.bashrc, ~/.zshrc, or equivalent shell config file."
+        echo ""
+        return 1
+    fi
+
+    # Test the command
+    DOCUCHANGO_VERSION=$(docuchango --version 2>&1 || echo "unknown")
+    print_success "docuchango is available: ${DOCUCHANGO_VERSION}"
+
+    # Test help command
+    if docuchango --help &> /dev/null; then
+        print_success "docuchango commands are working"
+    else
+        print_warning "docuchango command exists but help failed"
+        return 1
+    fi
+
+    return 0
+}
+
+show_next_steps() {
+    echo ""
+    echo -e "${GREEN}═══════════════════════════════════════════════${NC}"
+    echo -e "${GREEN}  Installation Complete!${NC}"
+    echo -e "${GREEN}═══════════════════════════════════════════════${NC}"
+    echo ""
+    echo "Next steps:"
+    echo ""
+    echo "1. View the bootstrap guide:"
+    echo -e "   ${BLUE}docuchango bootstrap${NC}"
+    echo ""
+    echo "2. View agent instructions:"
+    echo -e "   ${BLUE}docuchango bootstrap --guide agent${NC}"
+    echo ""
+    echo "3. Validate your documentation:"
+    echo -e "   ${BLUE}cd your-project${NC}"
+    echo -e "   ${BLUE}docuchango validate${NC}"
+    echo ""
+    echo "4. Get help:"
+    echo -e "   ${BLUE}docuchango --help${NC}"
+    echo ""
+    echo "For more information, visit:"
+    echo "  https://github.com/jrepp/docuchango"
+    echo ""
+}
+
+main() {
+    print_header
+
+    check_python
+    check_pip
+    check_uv
+
+    echo ""
+    install_docuchango
+
+    echo ""
+    if verify_installation; then
+        show_next_steps
+    else
+        echo ""
+        print_warning "Installation completed but verification had issues"
+        echo "Try running: docuchango --version"
+        echo ""
+        echo "If the command is not found, you may need to:"
+        echo "1. Restart your shell"
+        echo "2. Add Python's bin directory to your PATH"
+        echo ""
+    fi
+}
+
+# Run main installation
+main


### PR DESCRIPTION
## Summary
Adds installation scripts for easy deployment of docuchango on Unix/Linux/macOS and Windows platforms.

## Changes
- **install.sh**: Bash installer for Unix-like systems
- **install.ps1**: PowerShell installer for Windows

## Features
✅ Python version checking (requires >= 3.10)
✅ Automatic pip verification and installation
✅ Optional uv detection for faster installs
✅ Support for local development installs (`-e .`)
✅ Installation verification with helpful error messages
✅ PATH setup guidance if command not found
✅ Colored terminal output for better UX
✅ Next steps display with example commands

## Usage

### Unix/Linux/macOS
```bash
# From local repo
./install.sh

# Or from GitHub (when released)
curl -sSL https://raw.githubusercontent.com/jrepp/docuchango/main/install.sh | bash
```

### Windows
```powershell
# From local repo
./install.ps1

# Or from GitHub (when released)
irm https://raw.githubusercontent.com/jrepp/docuchango/main/install.ps1 | iex
```

## Testing
Tested successfully with:
- Python 3.10.18 in isolated venv
- `docuchango --version` works
- `docuchango bootstrap --guide agent` displays guide correctly
- `docuchango --help` shows all commands

## Future Enhancements
Consider adding pipx support as the primary installation method in a follow-up PR:
- pipx creates isolated environments automatically
- Automatic PATH management
- Standard for Python CLI tools
- Would provide better user experience

## Related
- Closes #[if there's an issue]
- Bootstrap command added in PR #3

🤖 Generated with Claude Code