### PR TITLE
Update README: fix license info and add bootstrap quick start

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,10 +31,28 @@ flowchart LR
 
 ## Quick Start
 
-```bash
-# Install
-pip install docuchango
+### 1. Bootstrap a docs-cms Project
 
+```bash
+# Install uv (if not already installed)
+curl -LsSf https://astral.sh/uv/install.sh | sh
+
+# Install docuchango
+curl -sSL https://raw.githubusercontent.com/jrepp/docuchango/main/install.sh | bash
+
+# View bootstrap guide
+docuchango bootstrap
+
+# View agent instructions
+docuchango bootstrap --guide agent
+
+# View best practices
+docuchango bootstrap --guide best-practices
+```
+
+### 2. Validate and Fix Documentation
+
+```bash
 # Validate
 docuchango validate
 
@@ -209,7 +227,9 @@ uv build
 
 ## License
 
-MIT - See LICENSE file
+Mozilla Public License Version 2.0 (MPL-2.0) - See [LICENSE](LICENSE) file
+
+This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 ## Links
 


### PR DESCRIPTION
## Summary
Updates README with correct license information and adds bootstrap as the first quick start example.

This PR contains the README updates that were added after PR #5 was merged.

## Changes

### 1. Fix License Information ✅

**Before:**
```
## License
MIT - See LICENSE file
```

**After:**
```
## License
Mozilla Public License Version 2.0 (MPL-2.0) - See LICENSE file

This Source Code Form is subject to the terms of the Mozilla Public 
License, v. 2.0. If a copy of the MPL was not distributed with this 
file, You can obtain one at https://mozilla.org/MPL/2.0/.
```

**Why this matters:**
- README previously showed "MIT" but LICENSE file contains MPL 2.0
- License badge already showed MPL 2.0
- Now all license references are consistent

### 2. Add Bootstrap as First Quick Start Example ✅

Reorganized Quick Start section into two parts:

**Section 1: Bootstrap a docs-cms Project** (NEW)
```bash
# Install uv (if not already installed)
curl -LsSf https://astral.sh/uv/install.sh | sh

# Install docuchango
curl -sSL https://raw.githubusercontent.com/jrepp/docuchango/main/install.sh | bash

# View bootstrap guide
docuchango bootstrap

# View agent instructions
docuchango bootstrap --guide agent

# View best practices
docuchango bootstrap --guide best-practices
```

**Section 2: Validate and Fix Documentation**
```bash
# Validate
docuchango validate

# Fix issues
docuchango fix all
```

## Benefits

### License Accuracy
- ✅ No more MIT/MPL 2.0 mismatch
- ✅ Includes standard MPL 2.0 source code notice
- ✅ Links to LICENSE file
- ✅ Matches badge and actual license

### Better Onboarding
- ✅ Complete setup from zero to working system
- ✅ Highlights bootstrap feature from PR #3
- ✅ Uses new uv-based installer from PR #5
- ✅ Shows all bootstrap command options
- ✅ Guides users through complete workflow

## Changes Made

**Files changed:** 1 (README.md)
**Lines:** +23, -3

## Context

This change was originally part of the work on PR #5 but was added after that PR was merged. It has been rebased on the current main branch for clean integration.

## Related

- Builds on PR #3 (Bootstrap CLI command)
- References PR #5 (uv-based installer)
- Fixes license documentation issue

🤖 Generated with Claude Code