### PR TITLE
feat: Add python-semantic-release for automated versioning

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,18 +39,24 @@ jobs:
         run: |
           git config user.name github-actions
           git config user.email github-actions@github.com
+
+          # Store the current tag before running semantic-release
+          OLD_TAG="$(git describe --tags --abbrev=0 2>/dev/null || echo 'none')"
+
+          # Run semantic-release
           uv tool run semantic-release version --no-push
-          # Check if version was bumped
-          if git diff --exit-code pyproject.toml > /dev/null 2>&1; then
-            echo "No version change detected"
+
+          # Check if a new tag was created
+          NEW_TAG="$(git describe --tags --abbrev=0 2>/dev/null || echo 'none')"
+
+          if [ "$OLD_TAG" = "$NEW_TAG" ]; then
+            echo "No version change detected (tag: $NEW_TAG)"
             echo "released=false" >> "$GITHUB_OUTPUT"
           else
-            echo "Version bumped, pushing changes"
+            echo "Version bumped from $OLD_TAG to $NEW_TAG"
             git push origin main --follow-tags
             echo "released=true" >> "$GITHUB_OUTPUT"
-            # Get the new version
-            NEW_VERSION="$(git describe --tags --abbrev=0)"
-            echo "version=${NEW_VERSION}" >> "$GITHUB_OUTPUT"
+            echo "version=${NEW_TAG}" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Create GitHub Release

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -243,7 +243,6 @@ match = "main"
 prerelease = false
 
 [tool.semantic_release.changelog]
-template_dir = "templates"
 exclude_commit_patterns = [
     "^chore\\(release\\):",
     "^Merge pull request",


### PR DESCRIPTION
## Summary

- Adds python-semantic-release for fully automated semantic versioning
- Configures release workflow to analyze conventional commits
- Automatically bumps versions, creates tags, and publishes GitHub releases
- Integrates with existing publish workflow for PyPI publishing

## Configuration

### pyproject.toml
- Added `[tool.semantic_release]` configuration
- Configured to parse conventional commit messages (feat, fix, etc.)
- Automatically updates version in `pyproject.toml`
- Generates changelog from commit history

### GitHub Actions Workflow
- New `.github/workflows/release.yml` workflow
- Triggers on pushes to main branch
- Uses concurrency control to prevent race conditions
- Analyzes commits since last release
- Creates GitHub releases which trigger existing PyPI publish workflow

## Test Plan

- [x] Validated workflow syntax with actionlint (no errors)
- [x] Tested semantic-release configuration locally in dry-run mode
- [x] Verified integration with existing workflows
- [ ] Merge PR and verify release workflow runs on main
- [ ] Test that conventional commit triggers proper version bump
- [ ] Verify PyPI publish workflow is triggered by release

## How It Works

After merging, when you push commits to main:
1. Release workflow analyzes commits using conventional commit format
2. Determines version bump (major/minor/patch) based on commit types
3. Updates version in pyproject.toml
4. Creates git tag and pushes to repository
5. Creates GitHub release with changelog
6. Existing publish workflow is triggered by release event
7. Package is automatically published to PyPI

## Commit Format

Use conventional commits for automatic versioning:
- `feat:` - Triggers minor version bump (0.1.0 -> 0.2.0)
- `fix:` - Triggers patch version bump (0.1.0 -> 0.1.1)
- `perf:` - Triggers patch version bump
- `BREAKING CHANGE:` - Triggers major version bump (0.1.0 -> 1.0.0)
- Other types (docs, chore, etc.) - No version bump

Generated with [Claude Code](https://claude.com/claude-code)