### PR TITLE
fix: use uv build command for semantic-release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -235,7 +235,7 @@ disable_error_code = ["no-untyped-call", "no-untyped-def", "no-any-return"]
 version_toml = ["pyproject.toml:project.version"]
 branch = "main"
 upload_to_vcs_release = true
-build_command = "pip install build && python -m build"
+build_command = "uv build"
 commit_message = "chore(release): {version}"
 
 [tool.semantic_release.branches.main]


### PR DESCRIPTION
## Summary

Fixes the semantic-release workflow build failure by changing the build command to use `uv build` instead of `pip install build && python -m build`.

## Problem

The release workflow was failing during the build step with:
```
/home/runner/work/_temp/setup-uv-cache/.../bin/python: No module named build
```

The workflow successfully:
- ✅ Detected the version should be `1.0.0`
- ✅ Analyzed commits using conventional commit format
- ✅ Prepared to create a release
- ❌ Failed during the build step

## Root Cause

The build command was trying to run `pip install build && python -m build` inside a uv-managed environment, but the `build` module wasn't accessible to the isolated Python environment that uv creates.

## Solution

Changed `pyproject.toml:238`:
```diff
- build_command = "pip install build && python -m build"
+ build_command = "uv build"
```

Using `uv build` directly:
- Works properly in uv-managed environments
- Eliminates the need for additional pip installations
- Matches the workflow's use of uv tooling

## Testing

After this change, the release workflow should:
1. Detect version changes from conventional commits
2. Successfully build distribution packages using `uv build`
3. Create git tags and GitHub releases automatically
4. Trigger the publish workflow to upload to PyPI

## Related

- Builds on PR #12 which added semantic-release infrastructure
- Completes the semantic versioning automation setup

🤖 Generated with [Claude Code](https://claude.com/claude-code)