### PR TITLE
fix: correct GitHub release creation command in workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,8 +62,6 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VERSION: ${{ steps.release.outputs.version }}
         run: |
-          uv tool run python-semantic-release changelog --unreleased
-          gh release create "${VERSION}" \
-            --title "${VERSION}" \
-            --notes-file CHANGELOG.md \
-            --verify-tag
+          # Use python-semantic-release to create the GitHub release
+          # This automatically extracts the relevant changelog section
+          uv tool run python-semantic-release publish --tag "${VERSION}"


### PR DESCRIPTION
## Summary

Fixes the remaining issue in the semantic-release workflow where the GitHub release creation step was using an invalid command option.

## Problem

After PR #13 fixed the build command, the workflow is now failing at the release creation step with:
```
Error: No such option: --unreleased
```

The command `python-semantic-release changelog --unreleased` doesn't exist. The `--unreleased` flag is not a valid option for the `changelog` command.

## Solution

Changed `.github/workflows/release.yml:65-69` from:
```yaml
run: |
  uv tool run python-semantic-release changelog --unreleased
  gh release create "${VERSION}" \
    --title "${VERSION}" \
    --notes-file CHANGELOG.md \
    --verify-tag
```

to:
```yaml
run: |
  # Use python-semantic-release to create the GitHub release
  # This automatically extracts the relevant changelog section
  uv tool run python-semantic-release publish --tag "${VERSION}"
```

## Why This Works

The `publish` command:
- ✅ Is designed to create VCS (GitHub) releases
- ✅ Automatically extracts the relevant changelog section for the tag
- ✅ Formats the release notes properly
- ✅ Handles the entire release creation process

This is simpler and more reliable than manually calling `gh release create`.

## Current Status

The workflow has successfully:
- ✅ Created version 1.0.0 (visible in pyproject.toml)
- ✅ Built distribution packages with `uv build`
- ✅ Updated CHANGELOG.md
- ✅ Created and pushed the git tag
- ❌ Failed to create GitHub release (this PR fixes it)

## After This PR

The workflow will be fully functional:
1. Analyze commits for version bumps
2. Build packages with `uv build` ✅ (fixed in PR #13)
3. Create GitHub releases with proper changelog ✅ (this PR)
4. Trigger PyPI publish workflow automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)