### PR TITLE
fix: correct semantic-release build command for uv environment

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -235,7 +235,7 @@ disable_error_code = ["no-untyped-call", "no-untyped-def", "no-any-return"]
 version_toml = ["pyproject.toml:project.version"]
 branch = "main"
 upload_to_vcs_release = true
-build_command = "pip install build && python -m build"
+build_command = "uv build"
 commit_message = "chore(release): {version}"
 
 [tool.semantic_release.branches.main]


### PR DESCRIPTION
Changed build_command from 'pip install build && python -m build' to 'uv build' to work properly in uv-managed environments.

The previous command failed because the build module wasn't available in the isolated uv python environment. Using 'uv build' directly ensures compatibility with the workflow's uv setup.

Resolves the "No module named build" error in the release workflow.