### PR TITLE
feat: add automatic PyPI publishing to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,12 +9,16 @@ permissions:
   contents: write
   issues: write
   pull-requests: write
+  id-token: write  # IMPORTANT: mandatory for trusted publishing to PyPI
 
 jobs:
   release:
     name: Semantic Release
     runs-on: ubuntu-latest
     concurrency: release
+    environment:
+      name: pypi
+      url: https://pypi.org/p/docuchango
 
     steps:
       - name: Check out the repository
@@ -85,3 +89,13 @@ jobs:
 
           # Clean up temporary file
           rm -f "$NOTES_FILE"
+
+      - name: Build distribution packages
+        if: steps.release.outputs.released == 'true'
+        run: uv build
+
+      - name: Publish to PyPI
+        if: steps.release.outputs.released == 'true'
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: dist/


### PR DESCRIPTION
## Summary

Adds automatic PyPI publishing directly to the release workflow, eliminating the need to manually trigger the publish workflow after each release.

## Problem

The release workflow creates GitHub releases successfully, but the publish workflow doesn't trigger automatically because:
- GitHub's `GITHUB_TOKEN` cannot trigger other workflows (security feature to prevent infinite loops)
- This required manually triggering the publish workflow with `gh workflow run publish.yml`

## Solution

Add PyPI publishing steps directly to the release workflow:
1. Build distribution packages (wheel + sdist) after creating the release
2. Publish to PyPI using trusted publishing with the `pypi` environment
3. Add required `id-token: write` permission for trusted publishing

## Changes

- Added `id-token: write` permission to the workflow
- Added `pypi` environment configuration to the release job  
- Added "Build distribution packages" step using `uv build`
- Added "Publish to PyPI" step using `pypa/gh-action-pypi-publish@release/v1`
- All new steps conditional on `steps.release.outputs.released == 'true'`

## Benefits

- ✅ Fully automated release process: commit → version bump → changelog → tag → GitHub release → PyPI publish
- ✅ No manual intervention required
- ✅ Single workflow reduces complexity
- ✅ Uses trusted publishing for security

## Testing

This workflow will be tested when the PR is merged and the next release is created.

🤖 Generated with [Claude Code](https://claude.com/claude-code)