### PR TITLE
fix: auto-populate version from package metadata

### DIFF
--- a/docuchango/__init__.py
+++ b/docuchango/__init__.py
@@ -16,7 +16,14 @@ Example:
     >>> validator.check_code_blocks()
 """
 
-__version__ = "0.1.2"
+from importlib.metadata import PackageNotFoundError, version
+
+try:
+    __version__ = version("docuchango")
+except PackageNotFoundError:
+    # Package is not installed, use fallback version
+    __version__ = "0.0.0.dev0"
+
 __author__ = "Jacob Repp"
 __email__ = "jacobrepp@gmail.com"
 

--- a/docuchango/cli.py
+++ b/docuchango/cli.py
@@ -12,11 +12,13 @@ from pathlib import Path
 import click
 from rich.console import Console
 
+from docuchango import __version__
+
 console = Console()
 
 
 @click.group()
-@click.version_option(version="0.1.2")
+@click.version_option(version=__version__)
 def main():
     """Docuchango - Docusaurus validation and repair framework."""
     pass


### PR DESCRIPTION
## Summary

- Replaces hardcoded version strings with dynamic version loading from package metadata
- Fixes version inconsistency where pyproject.toml had 1.2.0 while code had 0.1.2
- Ensures `--version` flag and `__version__` variable automatically reflect the version in pyproject.toml

## Changes

- **docuchango/__init__.py**: Updated to read version from installed package metadata using `importlib.metadata.version()` with a fallback for development scenarios
- **docuchango/cli.py**: Updated to use `__version__` from package instead of hardcoded string

## Benefits

- Version is now automatically synchronized with python-semantic-release
- No manual version updates needed in multiple files
- Single source of truth for version (pyproject.toml)

## Test plan

- [x] Verify `docuchango --version` displays correct version from pyproject.toml
- [x] Verify `from docuchango import __version__` returns correct version
- [x] Verify ruff linter passes
- [x] Verify mypy type checker passes
- [x] Test fallback version works in non-installed scenarios

🤖 Generated with [Claude Code](https://claude.com/claude-code)