### PR TITLE
fix: consistent YAML frontmatter formatting

### DIFF
--- a/docuchango/cli.py
+++ b/docuchango/cli.py
@@ -843,6 +843,7 @@ def migrate(
     import frontmatter
 
     from docuchango.fixes.timestamps import get_git_dates
+    from docuchango.fixes.yaml_utils import dumps as frontmatter_dumps
 
     # Find files to process
     root = target_path or Path.cwd()
@@ -1010,7 +1011,7 @@ def migrate(
 
             # Write changes
             if modified and not dry_run:
-                new_content = frontmatter.dumps(post)
+                new_content = frontmatter_dumps(post)
                 file_path.write_text(new_content, encoding="utf-8")
 
             # Report

--- a/docuchango/fixes/bulk_update.py
+++ b/docuchango/fixes/bulk_update.py
@@ -14,6 +14,8 @@ from pathlib import Path
 import frontmatter
 import yaml
 
+from docuchango.fixes.yaml_utils import dumps as frontmatter_dumps
+
 # Valid bulk update operations
 VALID_OPERATIONS = {"set", "add", "remove", "rename"}
 
@@ -137,7 +139,7 @@ def update_frontmatter_bulk(
 
     # Reconstruct content with updated frontmatter
     try:
-        new_content = frontmatter.dumps(post)
+        new_content = frontmatter_dumps(post)
         return new_content, True, message
     except Exception as e:
         return content, False, f"Error serializing frontmatter: {e}"

--- a/docuchango/fixes/frontmatter.py
+++ b/docuchango/fixes/frontmatter.py
@@ -14,6 +14,8 @@ from typing import Optional
 
 import frontmatter
 
+from docuchango.fixes.yaml_utils import dumps as frontmatter_dumps
+
 # Valid status values by document type
 VALID_STATUSES = {
     "adr": ["Proposed", "Accepted", "Deprecated", "Superseded"],
@@ -120,7 +122,7 @@ def fix_status_value(file_path: Path, dry_run: bool = False) -> tuple[bool, str]
             post.metadata["status"] = new_status
 
             if not dry_run:
-                file_path.write_text(frontmatter.dumps(post), encoding="utf-8")
+                file_path.write_text(frontmatter_dumps(post), encoding="utf-8")
 
             return True, f"Changed status from '{status}' to '{new_status}'"
 
@@ -130,7 +132,7 @@ def fix_status_value(file_path: Path, dry_run: bool = False) -> tuple[bool, str]
                 post.metadata["status"] = value
 
                 if not dry_run:
-                    file_path.write_text(frontmatter.dumps(post), encoding="utf-8")
+                    file_path.write_text(frontmatter_dumps(post), encoding="utf-8")
 
                 return True, f"Changed status from '{status}' to '{value}'"
 
@@ -165,31 +167,19 @@ def fix_date_format(file_path: Path, dry_run: bool = False) -> tuple[bool, str]:
 
         date_value = post.metadata[date_field]
 
-        # If already a date or datetime object, convert to string
+        # Native date/datetime objects from PyYAML mean the field was already
+        # an unquoted ISO 8601 value — the canonical format. No fix needed.
         if isinstance(date_value, datetime):
-            date_str = date_value.strftime("%Y-%m-%d")
-            post.metadata[date_field] = date_str
+            return False, "Date already in ISO 8601 format"
 
-            if not dry_run:
-                file_path.write_text(frontmatter.dumps(post), encoding="utf-8")
-
-            return True, f"Converted datetime object to ISO 8601: {date_str}"
-
-        # Handle datetime.date objects
         if hasattr(date_value, "strftime") and hasattr(date_value, "year"):
-            date_str = date_value.strftime("%Y-%m-%d")
-            post.metadata[date_field] = date_str
-
-            if not dry_run:
-                file_path.write_text(frontmatter.dumps(post), encoding="utf-8")
-
-            return True, f"Converted date object to ISO 8601: {date_str}"
+            return False, "Date already in ISO 8601 format"
 
         if not isinstance(date_value, str):
             return False, f"Date is not a string or date object: {type(date_value)}"
 
-        # Check if already ISO 8601
-        if re.match(r"^\d{4}-\d{2}-\d{2}$", date_value):
+        # Check if already ISO 8601 string (e.g. from a quoted value)
+        if re.match(r"^\d{4}-\d{2}-\d{2}(T\d{2}:\d{2}:\d{2}Z?)?$", date_value):
             return False, "Date already in ISO 8601 format"
 
         # Try various date formats
@@ -212,7 +202,7 @@ def fix_date_format(file_path: Path, dry_run: bool = False) -> tuple[bool, str]:
                 post.metadata[date_field] = iso_date
 
                 if not dry_run:
-                    file_path.write_text(frontmatter.dumps(post), encoding="utf-8")
+                    file_path.write_text(frontmatter_dumps(post), encoding="utf-8")
 
                 return True, f"Converted date from '{date_value}' to '{iso_date}'"
             except ValueError:

--- a/docuchango/fixes/tags.py
+++ b/docuchango/fixes/tags.py
@@ -14,6 +14,8 @@ from pathlib import Path
 
 import frontmatter
 
+from docuchango.fixes.yaml_utils import dumps as frontmatter_dumps
+
 
 def normalize_tag(tag: str) -> str:
     """Normalize a single tag to lowercase with dashes.
@@ -122,7 +124,7 @@ def fix_tags(file_path: Path, dry_run: bool = False) -> tuple[bool, list[str]]:
     if changed:
         if not dry_run:
             try:
-                new_content = frontmatter.dumps(post)
+                new_content = frontmatter_dumps(post)
                 file_path.write_text(new_content, encoding="utf-8")
             except Exception as e:
                 return False, [f"Error writing file: {e}"]

--- a/docuchango/fixes/whitespace.py
+++ b/docuchango/fixes/whitespace.py
@@ -12,6 +12,8 @@ from pathlib import Path
 
 import frontmatter
 
+from docuchango.fixes.yaml_utils import dumps as frontmatter_dumps
+
 
 def trim_string_values(metadata: dict) -> tuple[dict, list[str]]:
     """Trim whitespace from all string values in metadata.
@@ -169,7 +171,7 @@ def fix_whitespace_and_fields(file_path: Path, dry_run: bool = False) -> tuple[b
 
         if not dry_run:
             try:
-                new_content = frontmatter.dumps(post)
+                new_content = frontmatter_dumps(post)
                 file_path.write_text(new_content, encoding="utf-8")
             except Exception as e:
                 return False, [f"Error writing file: {e}"]

--- a/docuchango/fixes/yaml_utils.py
+++ b/docuchango/fixes/yaml_utils.py
@@ -1,0 +1,60 @@
+"""YAML serialization utilities for consistent frontmatter output.
+
+Provides a custom YAML dumper that ensures date-like strings are serialized
+without quotes, matching the behavior of native YAML date types. This prevents
+inconsistent quoting when dates are stored as strings vs datetime objects.
+"""
+
+from __future__ import annotations
+
+import re
+
+import frontmatter
+import yaml
+
+
+# Pattern matching ISO 8601 dates and datetimes
+_DATE_RE = re.compile(
+    r"^\d{4}-\d{2}-\d{2}"  # YYYY-MM-DD
+    r"(?:"  # optional time part
+    r"[T ]\d{2}:\d{2}:\d{2}"  # THH:MM:SS
+    r"(?:\.\d+)?"  # optional fractional seconds
+    r"(?:Z|[+-]\d{2}:\d{2})?"  # optional timezone
+    r")?$"
+)
+
+
+class _ConsistentDumper(yaml.SafeDumper):
+    """YAML dumper that outputs date-like strings without quotes."""
+
+    pass
+
+
+def _represent_str(dumper: yaml.Dumper, data: str) -> yaml.ScalarNode:
+    """Represent strings, using the timestamp tag for date-like values.
+
+    PyYAML's emitter quotes plain scalars that look like dates to avoid
+    ambiguity. By tagging them as timestamps, the emitter outputs them
+    unquoted, consistent with native date/datetime objects.
+    """
+    if _DATE_RE.match(data):
+        return dumper.represent_scalar("tag:yaml.org,2002:timestamp", data)
+    return yaml.SafeDumper.represent_str(dumper, data)
+
+
+_ConsistentDumper.add_representer(str, _represent_str)
+
+
+def dumps(post: frontmatter.Post) -> str:
+    """Serialize a frontmatter Post with consistent date formatting.
+
+    Drop-in replacement for frontmatter.dumps() that ensures date-like
+    strings are never single-quoted in the output.
+
+    Args:
+        post: A python-frontmatter Post object
+
+    Returns:
+        Serialized markdown string with frontmatter
+    """
+    return frontmatter.dumps(post, Dumper=_ConsistentDumper)

--- a/docuchango/fixes/yaml_utils.py
+++ b/docuchango/fixes/yaml_utils.py
@@ -1,13 +1,16 @@
 """YAML serialization utilities for consistent frontmatter output.
 
-Provides a custom YAML dumper that ensures date-like strings are serialized
-without quotes, matching the behavior of native YAML date types. This prevents
-inconsistent quoting when dates are stored as strings vs datetime objects.
+Provides a custom YAML dumper that minimizes formatting changes when
+round-tripping frontmatter through python-frontmatter/PyYAML:
+- Preserves field order (no alphabetical sorting)
+- Outputs dates/datetimes in ISO 8601 format (unquoted, with T separator)
+- Keeps short lists in flow style: [tag1, tag2]
 """
 
 from __future__ import annotations
 
 import re
+from datetime import date, datetime, timezone
 
 import frontmatter
 import yaml
@@ -25,7 +28,7 @@ _DATE_RE = re.compile(
 
 
 class _ConsistentDumper(yaml.SafeDumper):
-    """YAML dumper that outputs date-like strings without quotes."""
+    """YAML dumper that preserves formatting conventions."""
 
     pass
 
@@ -42,14 +45,54 @@ def _represent_str(dumper: yaml.Dumper, data: str) -> yaml.ScalarNode:
     return yaml.SafeDumper.represent_str(dumper, data)
 
 
+def _represent_datetime(dumper: yaml.Dumper, data: datetime) -> yaml.ScalarNode:
+    """Represent datetime objects in ISO 8601 format with T separator.
+
+    PyYAML's default uses space separator (2026-03-05 17:56:59+00:00).
+    We use the T separator and Z suffix to match the template format.
+    """
+    if data.tzinfo is not None:
+        utc = data.astimezone(timezone.utc)
+        value = utc.strftime("%Y-%m-%dT%H:%M:%SZ")
+    else:
+        value = data.strftime("%Y-%m-%dT%H:%M:%S")
+    return dumper.represent_scalar("tag:yaml.org,2002:timestamp", value)
+
+
+def _represent_date(dumper: yaml.Dumper, data: date) -> yaml.ScalarNode:
+    """Represent date objects in ISO 8601 format (YYYY-MM-DD), unquoted."""
+    return dumper.represent_scalar(
+        "tag:yaml.org,2002:timestamp", data.strftime("%Y-%m-%d")
+    )
+
+
+def _represent_list(dumper: yaml.Dumper, data: list) -> yaml.SequenceNode:  # type: ignore[type-arg]
+    """Represent lists, using flow style for short scalar lists.
+
+    Keeps tags: [architecture, design] instead of expanding to block style.
+    Falls back to block style for long lists or lists containing complex values.
+    """
+    use_flow = len(data) <= 10 and all(
+        isinstance(item, (str, int, float, bool)) for item in data
+    )
+    return dumper.represent_sequence(
+        "tag:yaml.org,2002:seq", data, flow_style=use_flow
+    )
+
+
 _ConsistentDumper.add_representer(str, _represent_str)
+_ConsistentDumper.add_representer(datetime, _represent_datetime)
+_ConsistentDumper.add_representer(date, _represent_date)
+_ConsistentDumper.add_representer(list, _represent_list)
 
 
 def dumps(post: frontmatter.Post) -> str:
-    """Serialize a frontmatter Post with consistent date formatting.
+    """Serialize a frontmatter Post with consistent formatting.
 
-    Drop-in replacement for frontmatter.dumps() that ensures date-like
-    strings are never single-quoted in the output.
+    Drop-in replacement for frontmatter.dumps() that:
+    - Preserves field order
+    - Outputs dates unquoted in ISO 8601 format
+    - Keeps short lists in flow style
 
     Args:
         post: A python-frontmatter Post object
@@ -57,4 +100,4 @@ def dumps(post: frontmatter.Post) -> str:
     Returns:
         Serialized markdown string with frontmatter
     """
-    return frontmatter.dumps(post, Dumper=_ConsistentDumper)
+    return frontmatter.dumps(post, Dumper=_ConsistentDumper, sort_keys=False)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "docuchango"
-version = "1.12.1"
+version = "1.12.2"
 description = "Docusaurus validation and repair framework for opinionated micro-CMS documentation, designed for human-agent collaboration workflows"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -397,8 +397,10 @@ doc_uuid: 12345678-1234-4123-8123-123456789abc
         post = frontmatter.loads(test_file.read_text(encoding="utf-8"))
         assert "date" not in post.metadata
         assert "created" in post.metadata
-        # created should be datetime format from git
-        assert "T" in post.metadata["created"]  # ISO 8601 datetime has T separator
+        # created should be a datetime (unquoted ISO 8601 parsed by PyYAML)
+        from datetime import datetime
+
+        assert isinstance(post.metadata["created"], datetime)
 
     def test_migrate_normalizes_created_to_datetime(self, tmp_path):
         """Test that migrate normalizes date-only 'created' to datetime format."""
@@ -443,9 +445,10 @@ doc_uuid: 12345678-1234-4123-8123-123456789abc
         # Verify created is now datetime format
         post = frontmatter.loads(test_file.read_text(encoding="utf-8"))
         assert "created" in post.metadata
-        # Should be ISO 8601 datetime format (YYYY-MM-DDTHH:MM:SSZ)
-        assert "T" in post.metadata["created"]
-        assert post.metadata["created"].endswith("Z")
+        # Unquoted ISO 8601 datetime is parsed by PyYAML as a datetime object
+        from datetime import datetime
+
+        assert isinstance(post.metadata["created"], datetime)
 
     def test_migrate_dry_run_no_changes(self, tmp_path):
         """Test that --dry-run doesn't modify files."""

--- a/tests/test_frontmatter_comprehensive.py
+++ b/tests/test_frontmatter_comprehensive.py
@@ -233,7 +233,10 @@ date: "01/02/2025"
         if changed:
             post = frontmatter.loads(doc.read_text())
             # Should be Feb 1, 2025 (US format)
-            assert post.metadata["date"] == "2025-02-01"
+            # Unquoted date is parsed by PyYAML as a date object
+            from datetime import date
+
+            assert post.metadata["date"] == date(2025, 2, 1)
 
     def test_partial_dates(self, tmp_path):
         """Test partial date formats."""

--- a/tests/test_frontmatter_fixes.py
+++ b/tests/test_frontmatter_fixes.py
@@ -1,7 +1,7 @@
 """Tests for frontmatter auto-fixes."""
 
 import uuid
-from datetime import datetime
+from datetime import date, datetime
 from pathlib import Path
 
 import frontmatter
@@ -180,7 +180,7 @@ date: 2025/01/26
         assert "2025-01-26" in msg
 
         post = frontmatter.loads(doc.read_text())
-        assert post.metadata["date"] == "2025-01-26"
+        assert post.metadata["date"] == date(2025, 1, 26)
 
     def test_fix_dot_format(self, tmp_path):
         """Test fixing date with dots."""
@@ -223,7 +223,7 @@ date: January 26, 2025
         assert "2025-01-26" in msg
 
     def test_already_iso_format(self, tmp_path):
-        """Test that ISO 8601 format date object is converted to string."""
+        """Test that unquoted ISO 8601 date (parsed as date object) needs no fix."""
         doc = tmp_path / "adr" / "adr-001-test.md"
         doc.parent.mkdir(parents=True)
 
@@ -238,23 +238,17 @@ date: 2025-01-26
 """
         doc.write_text(content)
 
-        # YAML parser will convert the date string to a date object
-        # so our fix should convert it back to a string
+        # Unquoted ISO 8601 date is already canonical — no fix needed
         changed, msg = fix_date_format(doc)
-        assert changed
-        assert "2025-01-26" in msg
+        assert not changed
+        assert "already in ISO 8601" in msg
 
-        # Verify it's now a string in the file
-        post = frontmatter.loads(doc.read_text())
-        assert post.metadata["date"] == "2025-01-26"
-        assert isinstance(post.metadata["date"], str)
-
-    def test_convert_datetime_object(self, tmp_path):
-        """Test converting datetime object to string."""
+    def test_datetime_object_already_valid(self, tmp_path):
+        """Test that a datetime object (from unquoted YAML) needs no fix."""
         doc = tmp_path / "adr" / "adr-001-test.md"
         doc.parent.mkdir(parents=True)
 
-        # Create frontmatter with datetime object
+        # Create frontmatter with datetime object (simulates unquoted datetime in YAML)
         post = frontmatter.Post("")
         post.metadata = {
             "id": "adr-001",
@@ -266,14 +260,10 @@ date: 2025-01-26
 
         doc.write_text(frontmatter.dumps(post))
 
+        # datetime objects from PyYAML are already canonical — no fix needed
         changed, msg = fix_date_format(doc)
-        assert changed
-        assert "2025-01-26" in msg
-
-        # Verify it's now a string
-        post = frontmatter.loads(doc.read_text())
-        assert post.metadata["date"] == "2025-01-26"
-        assert isinstance(post.metadata["date"], str)
+        assert not changed
+        assert "already in ISO 8601" in msg
 
 
 class TestAddMissingFrontmatter:
@@ -389,7 +379,7 @@ date: 2025/01/26
         # Verify fixes
         post = frontmatter.loads(doc.read_text())
         assert post.metadata["status"] == "Proposed"
-        assert post.metadata["date"] == "2025-01-26"
+        assert post.metadata["date"] == date(2025, 1, 26)
 
     def test_fix_all_dry_run(self, tmp_path):
         """Test that dry run doesn't persist changes."""


### PR DESCRIPTION
## Summary

- Add custom YAML dumper that ensures date-like strings are always serialized unquoted, matching the canonical template format (`created: 2026-03-05T17:56:59Z` not `created: '2026-03-05T17:56:59Z'`)
- Preserve original field order during round-trip instead of alphabetically sorting keys
- Output datetimes with T separator and Z suffix (not PyYAML's default space/offset format)
- Keep short scalar lists in flow style (`[tag1, tag2]`) instead of expanding to block style
- Stop treating native date/datetime objects from PyYAML as needing a fix (they indicate the field was already in correct unquoted ISO 8601 format)

## Test plan

- [x] All 495 existing tests pass
- [x] Verified `docuchango validate --dry-run` produces zero spurious fixes on a 37-file docs-cms project
- [x] Verified round-trip of frontmatter preserves field order, datetime format, list style, and unquoted dates

🤖 Generated with [Claude Code](https://claude.com/claude-code)