### PR TITLE
fix: preserve immutable created frontmatter timestamps

### DIFF
--- a/docuchango/cli.py
+++ b/docuchango/cli.py
@@ -654,8 +654,9 @@ def bulk_timestamps(
 ):
     """Derive created timestamp from git history.
 
-    Updates frontmatter 'created' field based on git commit history.
-    The 'created' date is set to the first commit datetime.
+    Adds missing frontmatter 'created' field based on git commit history.
+    Existing 'created' values are preserved as immutable metadata.
+    The added 'created' date is set to the first commit datetime.
 
     Also migrates legacy 'date' fields to the new 'created' format.
 
@@ -940,28 +941,18 @@ def migrate(
                 changes.append(f"Generated doc_uuid: {new_uuid}")
                 modified = True
 
-            # 3. Remove legacy 'date' field (will get created from git)
+            # 3. Remove legacy 'date' field
             if "date" in post.metadata:
                 del post.metadata["date"]
                 changes.append("Removed deprecated 'date' field")
                 modified = True
-                # Also remove created if it exists so it gets refreshed from git
-                if "created" in post.metadata:
-                    del post.metadata["created"]
 
-            # 4. Add or update created from git (ensures datetime format)
+            # 4. Add created from git only when missing (preserve immutability)
             created_datetime, _ = get_git_dates(file_path)
-            if created_datetime:
-                old_created = post.metadata.get("created")
-                # Normalize to datetime format from git
-                if old_created != created_datetime:
-                    old_val = str(old_created) if old_created else "None"
-                    post.metadata["created"] = created_datetime
-                    if old_created:
-                        changes.append(f"Normalized created: {old_val} → {created_datetime}")
-                    else:
-                        changes.append(f"Added created: {created_datetime} (from git)")
-                    modified = True
+            if created_datetime and "created" not in post.metadata:
+                post.metadata["created"] = created_datetime
+                changes.append(f"Added created: {created_datetime} (from git)")
+                modified = True
 
             # 5. Remove 'updated' field (derived from git history)
             if "updated" in post.metadata:

--- a/docuchango/cli.py
+++ b/docuchango/cli.py
@@ -941,17 +941,24 @@ def migrate(
                 changes.append(f"Generated doc_uuid: {new_uuid}")
                 modified = True
 
-            # 3. Remove legacy 'date' field
+            legacy_date = post.metadata.get("date")
+
+            # 3. Add created only when missing (preserve immutability)
+            if "created" not in post.metadata:
+                created_datetime, _ = get_git_dates(file_path)
+                if created_datetime:
+                    post.metadata["created"] = created_datetime
+                    changes.append(f"Added created: {created_datetime} (from git)")
+                    modified = True
+                elif legacy_date is not None:
+                    post.metadata["created"] = legacy_date
+                    changes.append("Added created from legacy 'date' field")
+                    modified = True
+
+            # 4. Remove legacy 'date' field once created is preserved or recovered
             if "date" in post.metadata:
                 del post.metadata["date"]
                 changes.append("Removed deprecated 'date' field")
-                modified = True
-
-            # 4. Add created from git only when missing (preserve immutability)
-            created_datetime, _ = get_git_dates(file_path)
-            if created_datetime and "created" not in post.metadata:
-                post.metadata["created"] = created_datetime
-                changes.append(f"Added created: {created_datetime} (from git)")
                 modified = True
 
             # 5. Remove 'updated' field (derived from git history)

--- a/docuchango/fixes/timestamps.py
+++ b/docuchango/fixes/timestamps.py
@@ -1,7 +1,7 @@
 """Update document timestamps based on git history.
 
 This module provides functionality to update document timestamps using git history:
-- For all docs: Update 'created' to first commit datetime
+- For all docs: Add missing 'created' from first commit datetime
 - Migrates legacy 'date' field in ADRs to 'created' field
 
 Note: The 'updated' field is not stored in frontmatter as it can be derived from git history.
@@ -180,22 +180,9 @@ def update_document_timestamps(file_path: Path, dry_run: bool = False) -> tuple[
         modified = True
         messages.append("Migrated 'date' → 'created'")
     else:
-        # Standard handling for created field
-        # Update or add created field
-        if "created" in post.metadata:
-            old_created = post.metadata["created"]
-            if isinstance(old_created, str):
-                old_created_str = old_created
-            elif hasattr(old_created, "strftime"):
-                old_created_str = old_created.strftime("%Y-%m-%dT%H:%M:%SZ")
-            else:
-                old_created_str = str(old_created)
-
-            if old_created_str != created_date:
-                new_content = update_frontmatter_field(new_content, "created", created_date)
-                modified = True
-                messages.append(f"Updated 'created': {old_created_str} → {created_date}")
-        else:
+        # Preserve immutable created field if already present.
+        # Only add missing created values from git history.
+        if "created" not in post.metadata:
             # Add missing created field
             # Try to insert after status field
             insert_pattern = r"(status:.*\n)"

--- a/docuchango/fixes/timestamps.py
+++ b/docuchango/fixes/timestamps.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 
 import re
 import subprocess
-from datetime import datetime, timezone
+from datetime import date, datetime, timezone
 from pathlib import Path
 
 import frontmatter
@@ -100,6 +100,37 @@ def update_frontmatter_field(content: str, field_name: str, new_value: str) -> s
     return re.sub(pattern, replacer, content, flags=re.MULTILINE)
 
 
+def remove_frontmatter_field(content: str, field_name: str) -> str:
+    """Remove a simple single-line field from YAML frontmatter."""
+    pattern = rf"^{field_name}:.*\n"
+    return re.sub(pattern, "", content, flags=re.MULTILINE)
+
+
+def insert_created_field(content: str, created_date: str) -> str:
+    """Insert a created field into frontmatter near other identity metadata."""
+    created_line = f"created: {created_date}\n"
+
+    for pattern in (r"(status:.*\n)", r"(id:.*\n)", r"(^---\n)"):
+        if re.search(pattern, content, flags=re.MULTILINE):
+            return re.sub(pattern, rf"\1{created_line}", content, count=1, flags=re.MULTILINE)
+
+    return content
+
+
+def frontmatter_value_to_string(value: object) -> str:
+    """Convert a parsed frontmatter value back to a YAML-friendly timestamp string."""
+    if isinstance(value, datetime):
+        if value.tzinfo is not None:
+            value = value.astimezone(timezone.utc)
+            return value.strftime("%Y-%m-%dT%H:%M:%SZ")
+        return value.strftime("%Y-%m-%dT%H:%M:%S")
+
+    if isinstance(value, date):
+        return value.strftime("%Y-%m-%d")
+
+    return str(value)
+
+
 def migrate_date_to_created(content: str, created_date: str) -> str:
     """Migrate legacy 'date' field to 'created' field.
 
@@ -108,30 +139,13 @@ def migrate_date_to_created(content: str, created_date: str) -> str:
         created_date: Creation date to use
 
     Returns:
-        Updated content with 'date' removed and 'created' added
+        Updated content with 'date' removed and 'created' added if needed
     """
-    # Remove the old 'date' field line
-    date_pattern = r"^date:.*\n"
-    new_content = re.sub(date_pattern, "", content, flags=re.MULTILINE)
+    new_content = remove_frontmatter_field(content, "date")
+    if re.search(r"^created:.*$", new_content, flags=re.MULTILINE):
+        return new_content
 
-    # Try to insert created after the status line
-    insert_pattern = r"(status:.*\n)"
-    created_line = f"created: {created_date}\n"
-
-    if re.search(insert_pattern, new_content, flags=re.MULTILINE):
-        # Status field exists, insert after it
-        new_content = re.sub(insert_pattern, rf"\1{created_line}", new_content, flags=re.MULTILINE)
-    else:
-        # No status field, insert after the id field or at the beginning of frontmatter
-        id_pattern = r"(id:.*\n)"
-        if re.search(id_pattern, new_content, flags=re.MULTILINE):
-            new_content = re.sub(id_pattern, rf"\1{created_line}", new_content, flags=re.MULTILINE)
-        else:
-            # Insert right after the opening ---
-            frontmatter_pattern = r"(---\n)"
-            new_content = re.sub(frontmatter_pattern, rf"\1{created_line}", new_content, flags=re.MULTILINE)
-
-    return new_content
+    return insert_created_field(new_content, created_date)
 
 
 def update_document_timestamps(file_path: Path, dry_run: bool = False) -> tuple[bool, list[str]]:
@@ -165,32 +179,36 @@ def update_document_timestamps(file_path: Path, dry_run: bool = False) -> tuple[
     if not post.metadata:
         return False, ["No frontmatter found"]
 
-    # Get git dates
-    created_date, updated_date = get_git_dates(file_path)
-    if not created_date:
-        return False, ["No git history found"]
-
     modified = False
     new_content = content
+    has_legacy_date = "date" in post.metadata
+    has_created = "created" in post.metadata
 
-    # Check if we need to migrate from legacy 'date' field
-    if "date" in post.metadata and "created" not in post.metadata:
-        # Legacy document with only 'date' field - migrate to 'created'
+    if has_legacy_date and has_created:
+        new_content = remove_frontmatter_field(new_content, "date")
+        if new_content != content:
+            modified = True
+            messages.append("Removed deprecated 'date' field")
+    elif has_legacy_date:
+        created_date, _ = get_git_dates(file_path)
+        if not created_date:
+            created_date = frontmatter_value_to_string(post.metadata["date"])
+
         new_content = migrate_date_to_created(new_content, created_date)
-        modified = True
-        messages.append("Migrated 'date' → 'created'")
+        if new_content != content:
+            modified = True
+            messages.append("Migrated 'date' → 'created'")
+    elif has_created:
+        return False, []
     else:
-        # Preserve immutable created field if already present.
-        # Only add missing created values from git history.
-        if "created" not in post.metadata:
-            # Add missing created field
-            # Try to insert after status field
-            insert_pattern = r"(status:.*\n)"
-            created_line = f"created: {created_date}\n"
-            if re.search(insert_pattern, new_content, flags=re.MULTILINE):
-                new_content = re.sub(insert_pattern, rf"\1{created_line}", new_content, flags=re.MULTILINE)
-                modified = True
-                messages.append(f"Added 'created': {created_date}")
+        created_date, _ = get_git_dates(file_path)
+        if not created_date:
+            return False, ["No git history found"]
+
+        new_content = insert_created_field(new_content, created_date)
+        if new_content != content:
+            modified = True
+            messages.append(f"Added 'created': {created_date}")
 
     # Write updated content
     if modified and not dry_run:

--- a/docuchango/fixes/yaml_utils.py
+++ b/docuchango/fixes/yaml_utils.py
@@ -15,7 +15,6 @@ from datetime import date, datetime, timezone
 import frontmatter
 import yaml
 
-
 # Pattern matching ISO 8601 dates and datetimes
 _DATE_RE = re.compile(
     r"^\d{4}-\d{2}-\d{2}"  # YYYY-MM-DD

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -402,8 +402,8 @@ doc_uuid: 12345678-1234-4123-8123-123456789abc
 
         assert isinstance(post.metadata["created"], datetime)
 
-    def test_migrate_normalizes_created_to_datetime(self, tmp_path):
-        """Test that migrate normalizes date-only 'created' to datetime format."""
+    def test_migrate_preserves_existing_created(self, tmp_path):
+        """Test that migrate preserves existing 'created' values."""
         # Create a git repo
         repo = tmp_path / "repo"
         adr_dir = repo / "adr"
@@ -440,15 +440,12 @@ doc_uuid: 12345678-1234-4123-8123-123456789abc
         result = runner.invoke(migrate, ["--project-id", "test-project", "--path", str(repo)])
 
         assert result.exit_code == 0
-        assert "Normalized created" in result.output
+        assert "Normalized created" not in result.output
 
-        # Verify created is now datetime format
+        # Verify created is preserved
         post = frontmatter.loads(test_file.read_text(encoding="utf-8"))
         assert "created" in post.metadata
-        # Unquoted ISO 8601 datetime is parsed by PyYAML as a datetime object
-        from datetime import datetime
-
-        assert isinstance(post.metadata["created"], datetime)
+        assert str(post.metadata["created"]) == "2025-01-01"
 
     def test_migrate_dry_run_no_changes(self, tmp_path):
         """Test that --dry-run doesn't modify files."""

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -402,6 +402,37 @@ doc_uuid: 12345678-1234-4123-8123-123456789abc
 
         assert isinstance(post.metadata["created"], datetime)
 
+    def test_migrate_uses_legacy_date_when_git_history_missing(self, tmp_path):
+        """Test that migrate preserves timestamp metadata without git history."""
+        adr_dir = tmp_path / "adr"
+        adr_dir.mkdir(parents=True)
+
+        test_file = adr_dir / "adr-001-test.md"
+        content = """---
+id: adr-001
+title: "Test ADR Title"
+status: Accepted
+date: "2025-01-01"
+deciders: "Core Team"
+tags:
+  - test
+project_id: test-project
+doc_uuid: 12345678-1234-4123-8123-123456789abc
+---
+
+# Test ADR
+"""
+        test_file.write_text(content, encoding="utf-8")
+
+        runner = CliRunner()
+        result = runner.invoke(migrate, ["--project-id", "test-project", "--path", str(tmp_path)])
+
+        assert result.exit_code == 0
+
+        post = frontmatter.loads(test_file.read_text(encoding="utf-8"))
+        assert "date" not in post.metadata
+        assert str(post.metadata["created"]) == "2025-01-01"
+
     def test_migrate_preserves_existing_created(self, tmp_path):
         """Test that migrate preserves existing 'created' values."""
         # Create a git repo
@@ -419,6 +450,7 @@ doc_uuid: 12345678-1234-4123-8123-123456789abc
 id: adr-001
 title: "Test ADR Title"
 status: Accepted
+date: "2024-12-31"
 created: "2025-01-01"
 deciders: "Core Team"
 tags:
@@ -444,6 +476,7 @@ doc_uuid: 12345678-1234-4123-8123-123456789abc
 
         # Verify created is preserved
         post = frontmatter.loads(test_file.read_text(encoding="utf-8"))
+        assert "date" not in post.metadata
         assert "created" in post.metadata
         assert str(post.metadata["created"]) == "2025-01-01"
 

--- a/tests/test_timestamp_fixes.py
+++ b/tests/test_timestamp_fixes.py
@@ -225,7 +225,7 @@ date: 2025-01-26
         assert "updated" not in post.metadata
 
     def test_update_existing_created_field(self, tmp_path):
-        """Test updating existing created field."""
+        """Test preserving existing created field."""
         # Create a git repo
         repo = tmp_path / "repo"
         repo.mkdir()
@@ -259,13 +259,12 @@ created: 2020-01-01
         # Update timestamps
         changed, messages = update_document_timestamps(doc)
 
-        assert changed
-        assert len(messages) == 1  # Only created should change
-        assert any("created" in msg for msg in messages)
+        assert not changed
+        assert messages == []
 
-        # Verify created date was updated from git
+        # Verify created date was preserved
         post = frontmatter.loads(doc.read_text())
-        assert post.metadata["created"] != "2020-01-01"
+        assert str(post.metadata["created"]) == "2020-01-01"
         # updated field is not stored anymore
         assert "updated" not in post.metadata
 

--- a/tests/test_timestamp_fixes.py
+++ b/tests/test_timestamp_fixes.py
@@ -268,6 +268,69 @@ created: 2020-01-01
         # updated field is not stored anymore
         assert "updated" not in post.metadata
 
+    def test_remove_legacy_date_when_created_exists(self, tmp_path):
+        """Test removing deprecated date while preserving existing created."""
+        repo = tmp_path / "repo"
+        repo.mkdir()
+
+        subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True)
+        subprocess.run(["git", "config", "user.email", "test@test.com"], cwd=repo, check=True, capture_output=True)
+        subprocess.run(["git", "config", "user.name", "Test User"], cwd=repo, check=True, capture_output=True)
+
+        doc = repo / "adr-001-test.md"
+        content = """---
+id: "adr-001"
+title: "Test"
+status: Accepted
+date: 2025-01-26
+created: 2020-01-01
+---
+
+# Test
+"""
+        doc.write_text(content)
+
+        subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True)
+        subprocess.run(
+            ["git", "commit", "-m", "Add doc"],
+            cwd=repo,
+            check=True,
+            capture_output=True,
+        )
+
+        changed, messages = update_document_timestamps(doc)
+
+        assert changed
+        assert messages == ["Removed deprecated 'date' field"]
+
+        post = frontmatter.loads(doc.read_text())
+        assert "date" not in post.metadata
+        assert str(post.metadata["created"]) == "2020-01-01"
+
+    def test_preserve_existing_created_without_git_history(self, tmp_path):
+        """Test existing created does not require git history."""
+        doc = tmp_path / "test.md"
+        doc.write_text("---\nid: test\ncreated: 2020-01-01\n---\n# Test")
+
+        changed, messages = update_document_timestamps(doc)
+
+        assert not changed
+        assert messages == []
+
+    def test_migrate_legacy_date_without_git_history(self, tmp_path):
+        """Test legacy date can be migrated without git history."""
+        doc = tmp_path / "test.md"
+        doc.write_text("---\nid: test\ndate: 2020-01-01\n---\n# Test")
+
+        changed, messages = update_document_timestamps(doc)
+
+        assert changed
+        assert messages == ["Migrated 'date' → 'created'"]
+
+        post = frontmatter.loads(doc.read_text())
+        assert "date" not in post.metadata
+        assert str(post.metadata["created"]) == "2020-01-01"
+
     def test_dry_run_no_changes(self, tmp_path):
         """Test that dry run doesn't write changes."""
         # Create a git repo

--- a/tests/test_timestamps_comprehensive.py
+++ b/tests/test_timestamps_comprehensive.py
@@ -276,7 +276,7 @@ class TestUpdateDocumentTimestampsEdgeCases:
             assert not changed
 
     def test_document_with_only_created(self, tmp_path):
-        """Test document with created field - should update it from git."""
+        """Test document with created field - should preserve existing value."""
         repo = tmp_path / "repo"
         repo.mkdir()
 
@@ -291,10 +291,12 @@ class TestUpdateDocumentTimestampsEdgeCases:
 
         changed, messages = update_document_timestamps(doc)
 
-        # Should update created field from git
-        assert changed
+        # Should preserve existing created field
+        assert not changed
+        assert messages == []
         post = frontmatter.loads(doc.read_text())
         assert "created" in post.metadata
+        assert str(post.metadata["created"]) == "2020-01-01"
         # updated field is no longer stored (derived from git)
         assert "updated" not in post.metadata
 

--- a/tests/test_timestamps_comprehensive.py
+++ b/tests/test_timestamps_comprehensive.py
@@ -229,9 +229,10 @@ created: 2019-01-01
 """
         result = migrate_date_to_created(content, "2021-01-01")
 
-        # Should remove date, add created
-        # Existing created might be overwritten
+        # Should remove date and preserve the existing created field
         assert "date: 2020-01-01" not in result
+        assert result.count("created:") == 1
+        assert "created: 2019-01-01" in result
 
     def test_migrate_multiline_date(self):
         """Test date field in multiline format."""
@@ -322,6 +323,28 @@ class TestUpdateDocumentTimestampsEdgeCases:
         assert "created" in post.metadata
         # updated field is no longer stored (derived from git)
         assert "updated" not in post.metadata
+
+    def test_document_with_id_but_no_status_adds_created(self, tmp_path):
+        """Test document without status still gets a created field."""
+        repo = tmp_path / "repo"
+        repo.mkdir()
+
+        subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True)
+        subprocess.run(["git", "config", "user.email", "test@test.com"], cwd=repo, check=True, capture_output=True)
+        subprocess.run(["git", "config", "user.name", "Test"], cwd=repo, check=True, capture_output=True)
+
+        doc = repo / "test.md"
+        doc.write_text("---\nid: test\n---\n# Test")
+        subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True)
+        subprocess.run(["git", "commit", "-m", "add"], cwd=repo, check=True, capture_output=True)
+
+        changed, _ = update_document_timestamps(doc)
+
+        assert changed
+        lines = doc.read_text().splitlines()
+        id_idx = next(i for i, line in enumerate(lines) if line.startswith("id:"))
+        created_idx = next(i for i, line in enumerate(lines) if line.startswith("created:"))
+        assert created_idx == id_idx + 1
 
     def test_corrupt_frontmatter(self, tmp_path):
         """Test file with corrupt frontmatter."""


### PR DESCRIPTION
## Summary
- preserve existing `created` frontmatter values as immutable metadata in timestamp fixes and migration flow
- only add `created` from git history when the field is missing, and keep legacy `date -> created` migration behavior
- update CLI/docs text and tests to assert that existing `created` values are no longer overwritten

## Validation
- `pytest tests/test_timestamp_fixes.py tests/test_timestamps_comprehensive.py tests/test_cli_commands.py`