### PR TITLE
chore: sync CMS document metadata and uv lock

### DIFF
--- a/docs-cms/adr/adr-001-pydantic-schema-validation.md
+++ b/docs-cms/adr/adr-001-pydantic-schema-validation.md
@@ -1,5 +1,5 @@
 ---
-created: 2025-10-26T02:35:12Z
+created: 2025-10-26T09:35:12Z
 deciders: Engineering Team
 doc_uuid: a1b2c3d4-e5f6-4a5b-8c9d-0e1f2a3b4c5d
 id: adr-001

--- a/docs-cms/adr/adr-002-click-cli-framework.md
+++ b/docs-cms/adr/adr-002-click-cli-framework.md
@@ -1,5 +1,5 @@
 ---
-created: 2025-10-26T02:35:12Z
+created: 2025-10-26T09:35:12Z
 deciders: Engineering Team
 doc_uuid: b2c3d4e5-f6a7-4b6c-9d0e-1f2a3b4c5d6e
 id: adr-002

--- a/docs-cms/adr/adr-003-pytest-tmp-path-testing.md
+++ b/docs-cms/adr/adr-003-pytest-tmp-path-testing.md
@@ -1,5 +1,5 @@
 ---
-created: 2025-10-26T02:35:12Z
+created: 2025-10-26T09:35:12Z
 deciders: Engineering Team
 doc_uuid: a04e65be-7296-4051-8a64-98cca8abcdb0
 id: adr-003

--- a/docs-cms/prd/prd-001-validation-framework.md
+++ b/docs-cms/prd/prd-001-validation-framework.md
@@ -1,15 +1,16 @@
 ---
 author: Engineering Team
-created: 2025-10-26T02:35:12Z
-doc_uuid: e5f6a7b8-c9d0-4e9f-2a3b-4c5d6e7f8a9b
+created: 2025-10-26T09:35:12Z
+doc_uuid: e5f6a7b8-c9d0-4e9f-8a3b-4c5d6e7f8a9b
 id: prd-001
 project_id: docuchango
-status: Launched
+status: Completed
 tags:
 - documentation
 - framework
 - product
 - validation
+target_release: v1.0.0
 title: 'Docuchango: Documentation Validation Tool'
 ---
 

--- a/uv.lock
+++ b/uv.lock
@@ -282,7 +282,7 @@ toml = [
 
 [[package]]
 name = "docuchango"
-version = "1.9.0"
+version = "1.12.2"
 source = { editable = "." }
 dependencies = [
     { name = "click", version = "8.1.8", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },


### PR DESCRIPTION
## Summary
- update the generated CMS document frontmatter to match the corrected release metadata
- align the editable package entry in `uv.lock` with the current `1.12.2` version
- isolate these cleanup-only changes on a branch based directly on `main`