### PR TITLE
docs: align CLI docs with current validate workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,21 +39,21 @@ curl -sSL https://raw.githubusercontent.com/jrepp/docuchango/main/install.sh | b
 ## Quick Start
 
 ```bash
-# Bootstrap a new docs-cms project with templates and structure
-docuchango bootstrap
+# Initialize a new docs-cms project with templates and structure
+docuchango init
 
-# Validate your documentation against frontmatter schemas, links, and formatting rules
+# Validate your documentation and auto-fix issues where possible
 docuchango validate
 
-# Automatically fix detected issues (code blocks, whitespace, frontmatter)
-docuchango fix all
+# Preview issues without changing files
+docuchango validate --dry-run
 ```
 
 ```mermaid
 flowchart LR
     A[docs-cms/] --> B{docuchango}
-    B -->|validate| C[✓ Report errors]
-    B -->|fix| D[✓ Fixed docs]
+    B -->|validate --dry-run| C[✓ Report issues]
+    B -->|validate| D[✓ Fix what it can]
     D --> E[Docusaurus]
     E -->|build| F[📚 Static site]
 
@@ -91,110 +91,23 @@ docuchango validate
 docuchango validate --skip-build
 ```
 
-### Fix Commands
+### Repair & Bulk Commands
 
 ```bash
-# List all available fixes and their descriptions
-$ docuchango fix list
-📋 Available Fixes
+# Validate and auto-fix common issues
+docuchango validate
 
-docuchango fix frontmatter
-  Fix frontmatter issues
-  Fixes:
-    • Invalid status values (maps to valid values by doc type)
-    • Invalid date formats (converts to ISO 8601: YYYY-MM-DD)
-    • Missing frontmatter blocks (generates with defaults)
-    ...
+# Preview fixes without changing files
+docuchango validate --dry-run --verbose
 
-# Automatically fix all detected issues
-$ docuchango fix all
-   ✓ Fixed 12 code blocks
-   ✓ Removed trailing whitespace
-   ✓ Added missing frontmatter
-
-# Fix specific issues
-docuchango fix code-blocks
-docuchango fix links
-
-# Fix frontmatter issues (status values, dates, missing fields)
-$ docuchango fix frontmatter --dry-run --verbose
-📋 Fixing Frontmatter Issues
-
-DRY RUN - No changes will be made
-
-Found 23 documentation files
-
-adr/adr-001.md
-  ✓ Changed status from 'Draft' to 'Proposed'
-  ✓ Converted date from '2025/01/26' to '2025-01-26'
-
-✓ Fixed 12 issues in 8 files
-
-# Apply the fixes
-docuchango fix frontmatter
-
-# Update timestamps based on git history
-$ docuchango fix timestamps --dry-run
-📅 Updating Document Timestamps
-
-Found 5 documentation files
-
-adr/adr-001.md
-  ✓ Migrated 'date' → 'created' and 'updated'
-
-✓ Fixed 5 issues in 5 files
+# Derive immutable created timestamps from git history
+docuchango bulk timestamps --dry-run
 
 # Bulk update frontmatter fields
-$ docuchango fix bulk-update --type adr --set status=Accepted --dry-run
-🔧 Bulk Update Frontmatter
+docuchango bulk update --type adr --set status=Accepted --dry-run
 
-Operation: SET
-Field: status = Accepted
-Document type filter: ADR
-Files found: 15
-
-adr/adr-001.md
-  ✓ Updated status: Proposed → Accepted
-
-adr/adr-005.md
-  ℹ Field status already has value 'Accepted'
-
-✓ 10 files would be updated
-
-# Bulk update operations support:
-# • SET - Update or add field (smart value detection)
-# • ADD - Add field only if it doesn't exist
-# • REMOVE - Delete field from frontmatter
-# • RENAME - Rename field (preserves value)
-# • Handles empty frontmatter gracefully
-# • Detects duplicate file references
-# • Provides clear feedback for each operation
-
-# Fix tags normalization
-$ docuchango fix tags --dry-run
-🏷️  Fixing Tags
-
-Found 23 documentation files
-
-adr/adr-001.md
-  ✓ Normalized tags: 3 tags
-  ✓ Removed 1 duplicate/invalid tags
-  ✓ Sorted tags alphabetically
-
-✓ Fixed 8 issues in 5 files
-
-# Fix whitespace and required fields
-$ docuchango fix whitespace --dry-run
-🧹 Fixing Whitespace & Fields
-
-Found 23 documentation files
-
-adr/adr-002.md
-  ✓ Trimmed whitespace from 'title' field
-  ✓ Generated missing 'doc_uuid'
-  ✓ Added missing 'tags' field (empty array)
-
-✓ Fixed 15 issues in 7 files
+# Migrate legacy frontmatter to the current schema
+docuchango migrate --project-id my-project --dry-run
 ```
 
 ### Bootstrap & Guides
@@ -209,7 +122,6 @@ docuchango bootstrap --guide best-practices
 
 ```bash
 dcc-validate        # Same as docuchango validate
-dcc-fix            # Same as docuchango fix
 ```
 
 ## CMS Folder Structure

--- a/docs/AGENT_GUIDE.md
+++ b/docs/AGENT_GUIDE.md
@@ -14,11 +14,11 @@ This guide is for AI agents working with projects that use `docs-cms` for docume
 ## Quick Reference Commands
 
 ```bash
-# Scan and validate all documentation
+# Validate all documentation and auto-fix what can be fixed
 docuchango validate
 
-# Auto-fix common issues
-docuchango fix
+# Preview issues without changing files
+docuchango validate --dry-run
 
 # Validate with detailed output
 docuchango validate --verbose
@@ -113,11 +113,11 @@ uuidgen | tr '[:upper:]' '[:lower:]'
 
 **Step 5**: Validate before committing
 ```bash
-# Validate the new document
-docuchango validate
+# Preview issues without changing files
+docuchango validate --dry-run
 
-# Fix any issues
-docuchango fix
+# Apply automatic fixes and validate the result
+docuchango validate
 
 # Verify it passes
 docuchango validate --verbose
@@ -335,11 +335,11 @@ Why this memo exists
 ### 1. Always Validate Before Committing
 
 ```bash
-# Run validation
-docuchango validate
+# Preview issues without changing files
+docuchango validate --dry-run
 
-# If errors found, fix them
-docuchango fix
+# Apply automatic fixes and report anything remaining
+docuchango validate
 
 # Verify fixes
 docuchango validate --verbose
@@ -727,7 +727,7 @@ docuchango validate --verbose
 # - Invalid status value
 
 # Auto-fix where possible
-docuchango fix
+docuchango validate
 
 # Check schema requirements
 cat docuchango/schemas.py | grep -A 20 "class ADRSchema"

--- a/docs/BEST_PRACTICES.md
+++ b/docs/BEST_PRACTICES.md
@@ -69,14 +69,11 @@ status: Accepted  # ← Agent shouldn't accept without human
 **Never commit without validation:**
 
 ```bash
-# Before every commit
+# Preview issues without changing files
+docuchango validate --dry-run
+
+# Apply automatic fixes and report anything remaining
 docuchango validate --verbose
-
-# If errors, fix them
-docuchango fix
-
-# Verify clean
-docuchango validate
 ```
 
 **Why**: Invalid documents break tooling, confuse other agents, and reduce trust in the CMS.
@@ -218,11 +215,11 @@ doc_uuid: 7c9e6679...         # ✓ Generated UUID v4
 #### Step 7: Validate and Commit
 
 ```bash
-# Validate
-docuchango validate
+# Preview issues
+docuchango validate --dry-run
 
-# Fix any issues
-docuchango fix
+# Apply automatic fixes
+docuchango validate
 
 # Commit
 git add docs-cms/adr/adr-042-redis-caching.md
@@ -567,9 +564,8 @@ grep -r "adr-015" docs-cms/
 ✅ **Solution**: Always validate:
 ```bash
 # Before committing
-docuchango validate
-docuchango fix  # if needed
-docuchango validate  # verify
+docuchango validate --dry-run
+docuchango validate --verbose
 
 git commit -m "..."
 ```

--- a/docs/BOOTSTRAP_GUIDE.md
+++ b/docs/BOOTSTRAP_GUIDE.md
@@ -210,11 +210,11 @@ EOF
 ### 6. Validate Your Documentation
 
 ```bash
-# Validate all documents
-docuchango validate
+# Preview issues without changing files
+docuchango validate --dry-run
 
-# Fix common issues
-docuchango fix
+# Validate all documents and auto-fix what can be fixed
+docuchango validate
 
 # Generate a report
 docuchango validate --verbose
@@ -335,8 +335,8 @@ node -e "console.log(require('crypto').randomUUID())"
 ### Running Validation
 
 ```bash
-# Quick validation
-docuchango validate
+# Preview issues without modifying files
+docuchango validate --dry-run
 
 # Verbose output
 docuchango validate --verbose
@@ -344,8 +344,8 @@ docuchango validate --verbose
 # Check specific directory
 docuchango validate --repo-root /path/to/project
 
-# Auto-fix issues
-docuchango fix
+# Apply automatic fixes
+docuchango validate
 ```
 
 ## Best Practices
@@ -367,8 +367,8 @@ docuchango fix
 1. **Create from template**: Copy and modify template
 2. **Add frontmatter**: Fill in all required fields
 3. **Write content**: Use clear, concise language
-4. **Validate**: Run `docuchango validate`
-5. **Fix issues**: Run `docuchango fix` or manually fix
+4. **Preview issues**: Run `docuchango validate --dry-run`
+5. **Apply fixes**: Run `docuchango validate` or manually fix any remaining issues
 6. **Commit**: Add to git with descriptive message
 7. **Review**: Have team review in PR
 

--- a/docuchango/templates/README.md
+++ b/docuchango/templates/README.md
@@ -52,14 +52,14 @@ Product requirements and feature specifications.
 Run validation to check your documents:
 
 ```bash
-# Validate all documents
+# Validate all documents and auto-fix what can be fixed
 docuchango validate
+
+# Preview issues without changing files
+docuchango validate --dry-run
 
 # Validate with verbose output
 docuchango validate --verbose
-
-# Auto-fix common issues
-docuchango validate --fix
 ```
 
 ## Configuration
@@ -75,7 +75,7 @@ Edit `docs-project.yaml` to customize:
 - Use meaningful, descriptive slugs in filenames
 - Keep frontmatter fields up to date
 - Use lowercase with dashes for IDs and filenames
-- Update the `updated` field when making changes
+- Preserve the `created` field once set; derive later updates from git history
 - Use appropriate tags for categorization
 - Link to related documents using relative paths
 

--- a/templates/README.md
+++ b/templates/README.md
@@ -56,13 +56,16 @@ Templates for creating structured documentation with proper frontmatter validati
 Required: `id`, `title`, `status`, `date`, `deciders`, `tags`, `project_id`, `doc_uuid`
 
 ### RFC (Request for Comments)
-Required: `id`, `title`, `status`, `author`, `created`, `updated`, `tags`, `project_id`, `doc_uuid`
+Required: `id`, `title`, `status`, `author`, `created`, `tags`, `project_id`, `doc_uuid`
 
 ### Memo
-Required: `id`, `title`, `author`, `date`, `created`, `updated`, `tags`, `project_id`, `doc_uuid`
+Required: `id`, `title`, `author`, `created`, `tags`, `project_id`, `doc_uuid`
 
-### PRD/FRD/PRDFAQ
-Required: `id`, `title`, `status`, `author`, `created`, `updated`, `tags`, `project_id`, `doc_uuid`
+### PRD
+Required: `id`, `title`, `status`, `author`, `created`, `target_release`, `tags`, `project_id`, `doc_uuid`
+
+### FRD/PRDFAQ
+Required: Follow the template frontmatter comments for the current fields used by those document types.
 
 ### Generic
 Required: `title`, `project_id`, `doc_uuid`
@@ -86,11 +89,11 @@ node -e "console.log(require('crypto').randomUUID())"
 All templates are designed to pass docuchango validation:
 
 ```bash
-# Validate a single document
-docuchango validate --repo-root /path/to/docs
+# Preview issues without changing files
+docuchango validate --repo-root /path/to/docs --dry-run
 
-# Fix common issues
-docuchango fix all --repo-root /path/to/docs
+# Apply automatic fixes
+docuchango validate --repo-root /path/to/docs
 ```
 
 ## Template Customization

--- a/tests/test_documentation_references.py
+++ b/tests/test_documentation_references.py
@@ -4,7 +4,6 @@ from pathlib import Path
 
 import pytest
 
-
 REPO_ROOT = Path(__file__).resolve().parents[1]
 
 USER_FACING_DOCS = [

--- a/tests/test_documentation_references.py
+++ b/tests/test_documentation_references.py
@@ -1,0 +1,41 @@
+"""Regression tests for user-facing command references in documentation."""
+
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+USER_FACING_DOCS = [
+    REPO_ROOT / "README.md",
+    REPO_ROOT / "docs" / "AGENT_GUIDE.md",
+    REPO_ROOT / "docs" / "BOOTSTRAP_GUIDE.md",
+    REPO_ROOT / "docs" / "BEST_PRACTICES.md",
+    REPO_ROOT / "templates" / "README.md",
+    REPO_ROOT / "docuchango" / "templates" / "README.md",
+]
+
+STALE_COMMAND_REFERENCES = [
+    "docuchango fix",
+    "dcc-fix",
+    "docuchango validate --fix",
+]
+
+
+@pytest.mark.parametrize("doc_path", USER_FACING_DOCS)
+def test_user_facing_docs_do_not_reference_removed_fix_commands(doc_path: Path):
+    """User-facing docs should match the current CLI surface."""
+    content = doc_path.read_text(encoding="utf-8")
+
+    for stale_reference in STALE_COMMAND_REFERENCES:
+        assert stale_reference not in content
+
+
+def test_readme_quick_start_uses_init_not_bootstrap():
+    """The README quick start should point users at the init command."""
+    readme = (REPO_ROOT / "README.md").read_text(encoding="utf-8")
+    quick_start = readme.split("## Quick Start", maxsplit=1)[1].split("## Usage Examples", maxsplit=1)[0]
+
+    assert "docuchango init" in quick_start
+    assert "docuchango bootstrap" not in quick_start


### PR DESCRIPTION
## Summary
- update the README quick start and bundled guides to use the current `init`, `validate`, and `bulk` commands
- remove stale references to the removed `docuchango fix`, `dcc-fix`, and `docuchango validate --fix` interfaces
- add a regression test so user-facing docs stay aligned with the shipped CLI surface

## Testing
- `uv run pytest tests/test_documentation_references.py tests/test_cli_commands.py -k \"documentation_references or test_all_subcommands_listed or test_main_help or test_validate_help\"`

Fixes #47