### PR TITLE
feat(validation): monorepo support for mixed doc layouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,30 @@ docuchango bulk update --type adr --set status=Accepted --dry-run
 docuchango migrate --project-id my-project --dry-run
 ```
 
+### Mixed-Schema Monorepos
+
+`docs-project.yaml` can map multiple document lanes in one repository with
+different schemas, naming rules, and roots. Generic lanes stay strict by
+default, but you can opt specific folders into plain Markdown when frontmatter
+is not a project goal.
+
+```yaml
+structure:
+  docs_roots: [docs]
+  doc_types:
+    adr:
+      schema: adr
+      folders: [adr]
+      filename_pattern: "^(adr)-(\\d{3})-(.+)\\.md$"
+      enforce_filename_pattern: true
+    design-notes:
+      schema: generic
+      folders: [design]
+      filename_pattern: ".+\\.md$"
+      enforce_filename_pattern: false
+      require_frontmatter: false
+```
+
 ### Bootstrap & Guides
 
 ```bash

--- a/docuchango/cli.py
+++ b/docuchango/cli.py
@@ -69,7 +69,7 @@ def _discover_doc_files(root: Path) -> list[Path]:
         "docs-cms/memos/**/*.md",
         "docs-cms/prd/**/*.md",
     ]
-    files: list[Path] = []
+    files = []
     for pattern in doc_patterns:
         files.extend(root.glob(pattern))
     return sorted(set(files))

--- a/docuchango/cli.py
+++ b/docuchango/cli.py
@@ -10,11 +10,90 @@ import sys
 from pathlib import Path
 
 import click
+import yaml
 from rich.console import Console
 
 from docuchango import __version__
+from docuchango.schemas import DocsProjectConfig
 
 console = Console()
+
+
+def _load_docs_project_config(root: Path) -> tuple[DocsProjectConfig | None, Path | None]:
+    """Load docs-project.yaml from repo root or docs-cms."""
+    candidates = [root / "docs-project.yaml", root / "docs-cms" / "docs-project.yaml"]
+    for candidate in candidates:
+        if not candidate.exists():
+            continue
+        try:
+            with candidate.open(encoding="utf-8") as f:
+                data = yaml.safe_load(f)
+            return DocsProjectConfig(**data), candidate
+        except Exception:
+            return None, candidate
+    return None, None
+
+
+def _discover_doc_files(root: Path) -> list[Path]:
+    """Discover markdown docs, preferring docs-project.yaml when present."""
+    config, config_path = _load_docs_project_config(root)
+
+    # New mixed-schema mode
+    if config and config.structure and config.structure.doc_types and config_path:
+        config_base = config_path.parent
+        roots = config.structure.docs_roots or ["."]
+        files: list[Path] = []
+        seen: set[Path] = set()
+
+        for doc_type_cfg in config.structure.doc_types.values():
+            for root_rel in roots:
+                root_path = (config_base / root_rel).resolve()
+                for folder in doc_type_cfg.folders:
+                    folder_path = (root_path / folder).resolve()
+                    if not folder_path.exists():
+                        continue
+                    for file_path in folder_path.rglob("*.md"):
+                        if file_path not in seen:
+                            seen.add(file_path)
+                            files.append(file_path)
+        return sorted(files)
+
+    # Legacy mode (backwards compatibility)
+    doc_patterns = [
+        "adr/**/*.md",
+        "rfcs/**/*.md",
+        "memos/**/*.md",
+        "prd/**/*.md",
+        "docs-cms/adr/**/*.md",
+        "docs-cms/rfcs/**/*.md",
+        "docs-cms/memos/**/*.md",
+        "docs-cms/prd/**/*.md",
+    ]
+    files: list[Path] = []
+    for pattern in doc_patterns:
+        files.extend(root.glob(pattern))
+    return sorted(set(files))
+
+
+def _guess_doc_type_from_path(file_path: Path) -> str | None:
+    """Best-effort document type inference from path segments."""
+    parts = [p.lower() for p in file_path.parts]
+    if "adr" in parts:
+        return "adr"
+    if "rfcs" in parts or "rfc" in parts:
+        return "rfc"
+    if "memos" in parts or "memo" in parts:
+        return "memo"
+    if "prd" in parts:
+        return "prd"
+    return None
+
+
+def _filter_files_by_doc_type(files: list[Path], doc_type: str | None) -> list[Path]:
+    """Filter discovered files by requested doc type."""
+    if not doc_type:
+        return files
+    return [f for f in files if _guess_doc_type_from_path(f) == doc_type]
 
 
 @click.group()
@@ -71,21 +150,7 @@ def validate(
     if dry_run:
         console.print("[yellow]DRY RUN - No changes will be made[/yellow]\n")
 
-    # Find all markdown files in docs directories
-    # Check both repo root and docs-cms subdirectory for compatibility
-    doc_patterns = [
-        "adr/**/*.md",
-        "rfcs/**/*.md",
-        "memos/**/*.md",
-        "prd/**/*.md",
-        "docs-cms/adr/**/*.md",
-        "docs-cms/rfcs/**/*.md",
-        "docs-cms/memos/**/*.md",
-        "docs-cms/prd/**/*.md",
-    ]
-    all_files = []
-    for pattern in doc_patterns:
-        all_files.extend(repo_root.glob(pattern))
+    all_files = _discover_doc_files(repo_root)
 
     # Track fixes applied and remaining issues
     fixes_applied: list[tuple[Path, str]] = []
@@ -569,31 +634,7 @@ def bulk_update(
     # Find files to process
     root = target_path or Path.cwd()
 
-    # Build glob patterns based on doc_type filter
-    if doc_type:
-        type_dirs = {
-            "adr": ["adr"],
-            "rfc": ["rfcs"],
-            "memo": ["memos"],
-            "prd": ["prd"],
-        }
-        patterns = [f"{d}/**/*.md" for d in type_dirs[doc_type]]
-        patterns += [f"docs-cms/{d}/**/*.md" for d in type_dirs[doc_type]]
-    else:
-        patterns = [
-            "adr/**/*.md",
-            "rfcs/**/*.md",
-            "memos/**/*.md",
-            "prd/**/*.md",
-            "docs-cms/adr/**/*.md",
-            "docs-cms/rfcs/**/*.md",
-            "docs-cms/memos/**/*.md",
-            "docs-cms/prd/**/*.md",
-        ]
-
-    all_files = []
-    for pattern in patterns:
-        all_files.extend(root.glob(pattern))
+    all_files = _filter_files_by_doc_type(_discover_doc_files(root), doc_type)
 
     if not all_files:
         console.print("[yellow]No files found matching criteria[/yellow]")
@@ -685,31 +726,7 @@ def bulk_timestamps(
     # Find files to process
     root = target_path or Path.cwd()
 
-    # Build glob patterns based on doc_type filter
-    if doc_type:
-        type_dirs = {
-            "adr": ["adr"],
-            "rfc": ["rfcs"],
-            "memo": ["memos"],
-            "prd": ["prd"],
-        }
-        patterns = [f"{d}/**/*.md" for d in type_dirs[doc_type]]
-        patterns += [f"docs-cms/{d}/**/*.md" for d in type_dirs[doc_type]]
-    else:
-        patterns = [
-            "adr/**/*.md",
-            "rfcs/**/*.md",
-            "memos/**/*.md",
-            "prd/**/*.md",
-            "docs-cms/adr/**/*.md",
-            "docs-cms/rfcs/**/*.md",
-            "docs-cms/memos/**/*.md",
-            "docs-cms/prd/**/*.md",
-        ]
-
-    all_files = []
-    for pattern in patterns:
-        all_files.extend(root.glob(pattern))
+    all_files = _filter_files_by_doc_type(_discover_doc_files(root), doc_type)
 
     if not all_files:
         console.print("[yellow]No files found matching criteria[/yellow]")
@@ -849,31 +866,7 @@ def migrate(
     # Find files to process
     root = target_path or Path.cwd()
 
-    # Build glob patterns based on doc_type filter
-    if doc_type:
-        type_dirs = {
-            "adr": ["adr"],
-            "rfc": ["rfcs"],
-            "memo": ["memos"],
-            "prd": ["prd"],
-        }
-        patterns = [f"{d}/**/*.md" for d in type_dirs[doc_type]]
-        patterns += [f"docs-cms/{d}/**/*.md" for d in type_dirs[doc_type]]
-    else:
-        patterns = [
-            "adr/**/*.md",
-            "rfcs/**/*.md",
-            "memos/**/*.md",
-            "prd/**/*.md",
-            "docs-cms/adr/**/*.md",
-            "docs-cms/rfcs/**/*.md",
-            "docs-cms/memos/**/*.md",
-            "docs-cms/prd/**/*.md",
-        ]
-
-    all_files = []
-    for pattern in patterns:
-        all_files.extend(root.glob(pattern))
+    all_files = _filter_files_by_doc_type(_discover_doc_files(root), doc_type)
 
     if not all_files:
         console.print("[yellow]No files found matching criteria[/yellow]")

--- a/docuchango/schemas.py
+++ b/docuchango/schemas.py
@@ -35,6 +35,13 @@ class DocTypeConfig(BaseModel):
         default=True,
         description="Whether filename_pattern should be enforced when provided",
     )
+    require_frontmatter: bool = Field(
+        default=True,
+        description=(
+            "Whether documents in this lane must include YAML frontmatter. "
+            "Set false for plain-Markdown generic lanes in mixed-schema repos."
+        ),
+    )
     model_config = ConfigDict(populate_by_name=True)
 
     frontmatter_schema: Literal["adr", "rfc", "memo", "prd", "generic"] = Field(

--- a/docuchango/schemas.py
+++ b/docuchango/schemas.py
@@ -10,7 +10,38 @@ import datetime
 import re
 from typing import Literal
 
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+
+class DocTypeConfig(BaseModel):
+    """Configuration for a single document type in docs-project.yaml.
+
+    This enables mixed document schemas in monorepos, including:
+    - numeric-prefix formats (e.g., adr-001-...)
+    - non-numeric formats (e.g., prfaq-why-now.md)
+    - custom folders per document type
+    - custom schema binding (adr/rfc/memo/prd/generic)
+    """
+
+    folders: list[str] = Field(
+        default_factory=list,
+        description="Folders (relative to config file directory) containing this document type",
+    )
+    filename_pattern: str | None = Field(
+        default=None,
+        description="Optional regex enforced against file names (not full paths)",
+    )
+    enforce_filename_pattern: bool = Field(
+        default=True,
+        description="Whether filename_pattern should be enforced when provided",
+    )
+    model_config = ConfigDict(populate_by_name=True)
+
+    frontmatter_schema: Literal["adr", "rfc", "memo", "prd", "generic"] = Field(
+        alias="schema",
+        default="generic",
+        description="Frontmatter schema to validate against for this document type",
+    )
 
 
 class DocsProjectStructure(BaseModel):
@@ -43,6 +74,17 @@ class DocsProjectStructure(BaseModel):
     document_folders: list[str] = Field(
         default_factory=lambda: ["adr", "rfcs", "memos", "prd"],
         description="List of folders to scan for documents. Override to customize which folders are validated. Default: ['adr', 'rfcs', 'memos', 'prd']",
+    )
+    docs_roots: list[str] = Field(
+        default_factory=lambda: ["."],
+        description="Optional list of roots (relative to the config file directory) to scan for folders. Useful for monorepos.",
+    )
+    doc_types: dict[str, DocTypeConfig] | None = Field(
+        default=None,
+        description=(
+            "Optional custom document type map for mixed-schema repositories. "
+            "When provided, this takes precedence over adr_dir/rfc_dir/memo_dir/prd_dir."
+        ),
     )
 
 

--- a/docuchango/templates/docs-project.yaml
+++ b/docuchango/templates/docs-project.yaml
@@ -35,6 +35,12 @@ structure:
   #     folders: [prfaq]
   #     filename_pattern: "^prfaq-.+\\.md$"
   #     enforce_filename_pattern: true
+  #   design-notes:
+  #     schema: generic
+  #     folders: [design]
+  #     filename_pattern: ".+\\.md$"
+  #     enforce_filename_pattern: false
+  #     require_frontmatter: false  # Allow plain Markdown design notes
 
 metadata:
   created: "2025-01-01"

--- a/docuchango/templates/docs-project.yaml
+++ b/docuchango/templates/docs-project.yaml
@@ -9,6 +9,11 @@ structure:
   memo_dir: memos
   prd_dir: prd
   template_dir: templates
+  # Optional roots to scan (relative to this file). Useful in monorepos.
+  # docs_roots:
+  #   - .
+  #   - ../project-a/docs
+  #   - ../project-b/docs
   # List of folders to scan for documents
   # Override this to customize which folders are validated
   document_folders:
@@ -16,6 +21,20 @@ structure:
     - rfcs
     - memos
     - prd
+
+  # Optional advanced mapping for mixed schemas/layouts in one repository.
+  # When doc_types is set, it takes precedence over adr_dir/rfc_dir/memo_dir/prd_dir.
+  # doc_types:
+  #   adr:
+  #     schema: adr
+  #     folders: [adr]
+  #     filename_pattern: "^(adr)-(\\d{3})-(.+)\\.md$"
+  #     enforce_filename_pattern: true
+  #   prfaq:
+  #     schema: generic
+  #     folders: [prfaq]
+  #     filename_pattern: "^prfaq-.+\\.md$"
+  #     enforce_filename_pattern: true
 
 metadata:
   created: "2025-01-01"

--- a/docuchango/validator.py
+++ b/docuchango/validator.py
@@ -40,6 +40,7 @@ try:
     # Import schemas from the docuchango package
     from docuchango.schemas import (
         ADRFrontmatter,
+        DocTypeConfig,
         DocsProjectConfig,
         GenericDocFrontmatter,
         MemoFrontmatter,
@@ -136,27 +137,43 @@ class DocValidator:
         self.errors: list[str] = []
 
         # Load project configuration
+        self.project_config_path: Path | None = None
         self.project_config = self._load_project_config()
 
     def _load_project_config(self) -> Optional[DocsProjectConfig]:
         """Load docs-project.yaml configuration"""
-        config_path = self.repo_root / "docs-cms" / "docs-project.yaml"
-        if config_path.exists():
+        candidate_paths = [
+            self.repo_root / "docs-project.yaml",
+            self.repo_root / "docs-cms" / "docs-project.yaml",
+        ]
+
+        for config_path in candidate_paths:
+            if not config_path.exists():
+                continue
+
             try:
                 with open(config_path, encoding="utf-8") as f:
                     config_data = yaml.safe_load(f)
                     config = DocsProjectConfig(**config_data)
-                    self.log(f"✓ Loaded project config: {config.project.id}")
+                    self.project_config_path = config_path
+                    self.log(f"✓ Loaded project config: {config.project.id} ({config_path})")
                     return config
             except ValidationError as e:
-                self.log(f"⚠️  Warning: Invalid project config format: {e}")
+                self.log(f"⚠️  Warning: Invalid project config format at {config_path}: {e}")
                 return None
             except Exception as e:
-                self.log(f"⚠️  Warning: Could not load project config: {e}")
+                self.log(f"⚠️  Warning: Could not load project config at {config_path}: {e}")
                 return None
-        else:
-            self.log(f"⚠️  Warning: Project config not found at {config_path}")
-            return None
+
+        self.log("⚠️  Warning: Project config not found (looked for docs-project.yaml at repo root and docs-cms/)")
+        return None
+
+    def _get_config_base_dir(self) -> Path:
+        """Base directory for resolving structure paths."""
+        if self.project_config_path:
+            return self.project_config_path.parent
+        # Legacy default
+        return self.repo_root / "docs-cms"
 
     def log(self, message: str, force: bool = False):
         """Log if verbose or forced"""
@@ -187,31 +204,73 @@ class DocValidator:
         # Default folders to scan (includes prd now!)
         return ["adr", "rfcs", "memos", "prd"]
 
-    def _scan_document_folder(self, folder_name: str, doc_type: str, pattern: re.Pattern[str]):
+    def _build_scan_entries(self) -> list[tuple[str, str, str, bool, Path]]:
+        """Build scan entries as tuples:
+
+        (doc_type, folder_relative, filename_pattern, enforce_filename_pattern, root_path)
+        """
+        default_patterns = {
+            "adr": r"^(adr)-(\d{3})-(.+)\.md$",
+            "rfc": r"^(rfc)-(\d{3})-(.+)\.md$",
+            "memo": r"^(memo)-(\d{3})-(.+)\.md$",
+            "prd": r"^(prd)-(\d{3})-(.+)\.md$",
+        }
+
+        config_base = self._get_config_base_dir()
+
+        if self.project_config and self.project_config.structure and self.project_config.structure.doc_types:
+            roots = self.project_config.structure.docs_roots or ["."]
+            entries: list[tuple[str, str, str, bool, Path]] = []
+
+            for doc_type_name, cfg in self.project_config.structure.doc_types.items():
+                if not isinstance(cfg, DocTypeConfig):
+                    continue
+                pattern = cfg.filename_pattern or default_patterns.get(doc_type_name, r"^(.+)\.md$")
+                folders = cfg.folders or []
+                for root_rel in roots:
+                    root_path = (config_base / root_rel).resolve()
+                    for folder in folders:
+                        entries.append((cfg.frontmatter_schema, folder, pattern, cfg.enforce_filename_pattern, root_path))
+            return entries
+
+        # Legacy behavior
+        folder_config = self._get_folder_config()
+        document_folders = self._get_document_folders()
+
+        entries = []
+        for key, schema_name in [("adr", "adr"), ("rfc", "rfc"), ("memo", "memo"), ("prd", "prd")]:
+            folder_name = folder_config[key]
+            if folder_name in document_folders:
+                entries.append((schema_name, folder_name, default_patterns[schema_name], True, config_base))
+        return entries
+
+    def _scan_document_folder(
+        self, folder_path: Path, folder_name: str, doc_type: str, pattern: re.Pattern[str], enforce_filename_pattern: bool
+    ):
         """Scan a specific document folder for markdown files"""
-        folder_path = self.repo_root / "docs-cms" / folder_name
         if not folder_path.exists():
-            self.log(f"   ⊘ Folder {folder_name} does not exist, skipping")
+            self.log(f"   ⊘ Folder {folder_path} does not exist, skipping")
             return
 
-        for md_file in folder_path.glob("*.md"):
+        for md_file in folder_path.rglob("*.md"):
             # Skip README and index files (landing pages)
             if md_file.name in ["README.md", "index.md"]:
                 continue
 
             match = pattern.match(md_file.name)
-            if not match:
+            if enforce_filename_pattern and not match:
                 self.errors.append(
-                    f"Invalid {doc_type.upper()} filename: {md_file.name} (expected: {doc_type}-NNN-name-with-dashes.md - lowercase only)"
+                    f"Invalid {doc_type.upper()} filename: {md_file.name} (pattern: {pattern.pattern})"
                 )
-                self.log(f"   ✗ {md_file.name}: Invalid filename format (must be lowercase)")
+                self.log(f"   ✗ {md_file.name}: Invalid filename format")
                 continue
 
-            _prefix, num, _slug = match.groups()
-            # Skip template files (000)
-            if num == "000":
-                self.log(f"   ⊘ {md_file.name}: Skipping template file")
-                continue
+            if match and len(match.groups()) >= 2:
+                _prefix, num = match.groups()[:2]
+                # Skip template files (000)
+                if num == "000":
+                    self.log(f"   ⊘ {md_file.name}: Skipping template file")
+                    continue
 
             doc = self._parse_document(md_file, doc_type)
             if doc:
@@ -222,61 +281,36 @@ class DocValidator:
         """Scan all markdown files"""
         self.log("\n📂 Scanning documents...")
 
-        # Get folder configuration
-        folder_config = self._get_folder_config()
-        document_folders = self._get_document_folders()
+        entries = self._build_scan_entries()
+        if not entries:
+            self.log("   ⊘ No configured scan entries found", force=True)
 
-        # Filename patterns (type-NNN-name-with-dashes.md)
-        # ENFORCE lowercase only - uppercase is deprecated
-        patterns = {
-            "adr": re.compile(r"^(adr)-(\d{3})-(.+)\.md$"),
-            "rfc": re.compile(r"^(rfc)-(\d{3})-(.+)\.md$"),
-            "memo": re.compile(r"^(memo)-(\d{3})-(.+)\.md$"),
-            "prd": re.compile(r"^(prd)-(\d{3})-(.+)\.md$"),
-        }
-
-        # Map folder names to document types and detect duplicates
-        folder_to_types: dict[str, list[str]] = {}
-        for key, doc_type in [("adr", "adr"), ("rfc", "rfc"), ("memo", "memo"), ("prd", "prd")]:
-            folder = folder_config[key]
-            if folder not in folder_to_types:
-                folder_to_types[folder] = []
-            folder_to_types[folder].append(doc_type)
-
-        # Warn about duplicate folder mappings
-        for folder, types in folder_to_types.items():
-            if len(types) > 1:
-                self.log(
-                    f"⚠️  Warning: Folder '{folder}' is mapped to multiple document types: {types}. "
-                    f"This may cause ambiguous validation. Consider using unique folder names.",
-                    force=True,
-                )
-
-        # Scan configured document folders
-        for folder_name in document_folders:
-            doc_types = folder_to_types.get(folder_name, [])
-            if not doc_types:
-                self.log(
-                    f"⚠️  Warning: Document folder '{folder_name}' is not recognized and will be skipped. "
-                    f"Please check your configuration.",
-                    force=True,
-                )
+        for doc_type, folder_name, pattern_text, enforce_pattern, root_path in entries:
+            try:
+                pattern = re.compile(pattern_text)
+            except re.error as e:
+                self.errors.append(f"Invalid filename regex for {doc_type}/{folder_name}: {e}")
                 continue
 
-            for doc_type in doc_types:
-                if doc_type in patterns:
-                    self.log(f"   Scanning {folder_name}/ ({doc_type} documents)...")
-                    self._scan_document_folder(folder_name, doc_type, patterns[doc_type])
+            folder_path = (root_path / folder_name).resolve()
+            self.log(f"   Scanning {folder_path} ({doc_type} documents)...")
+            self._scan_document_folder(folder_path, folder_name, doc_type, pattern, enforce_pattern)
 
-        # Scan general docs (root level)
-        docs_dir = self.repo_root / "docs-cms"
-        if docs_dir.exists():
+        # Scan general docs markdown files at docs roots
+        roots_to_scan = [self._get_config_base_dir()]
+        if self.project_config and self.project_config.structure:
+            roots_to_scan = [(self._get_config_base_dir() / p).resolve() for p in self.project_config.structure.docs_roots]
+
+        for docs_dir in roots_to_scan:
+            if not docs_dir.exists():
+                continue
             for md_file in docs_dir.glob("*.md"):
-                if md_file.name not in ["README.md"]:
-                    doc = self._parse_document(md_file, "doc")
-                    if doc:
-                        self.documents.append(doc)
-                        self.file_to_doc[md_file] = doc
+                if md_file.name in ["README.md", "docs-project.yaml"]:
+                    continue
+                doc = self._parse_document(md_file, "doc")
+                if doc:
+                    self.documents.append(doc)
+                    self.file_to_doc[md_file] = doc
 
         self.log(f"   Found {len(self.documents)} documents")
 
@@ -1052,7 +1086,7 @@ class DocValidator:
 
         for doc in self.documents:
             # Skip docs without doc_type (generic docs)
-            if doc.doc_type not in ["adr", "rfc", "memo"]:
+            if doc.doc_type not in ["adr", "rfc", "memo", "prd"]:
                 continue
 
             # Check if ID exists
@@ -1066,7 +1100,7 @@ class DocValidator:
             # Extract expected ID from filename
             filename = doc.file_path.name
             # Match adr-XXX, rfc-XXX, or memo-XXX pattern (lowercase only)
-            filename_pattern = re.compile(r"^(adr|rfc|memo)-(\d{3})-")
+            filename_pattern = re.compile(r"^(adr|rfc|memo|prd)-(\d{3})-")
             match = filename_pattern.match(filename)
 
             if not match:
@@ -1088,7 +1122,7 @@ class DocValidator:
                 id_errors += 1
 
             # Check ID matches title number
-            title_pattern = re.compile(r"^(ADR|RFC|MEMO)-(\d{3}):", re.IGNORECASE)
+            title_pattern = re.compile(r"^(ADR|RFC|MEMO|PRD)-(\d{3}):", re.IGNORECASE)
             title_match = title_pattern.match(doc.title)
             if title_match:
                 title_prefix, title_num = title_match.groups()

--- a/docuchango/validator.py
+++ b/docuchango/validator.py
@@ -40,7 +40,6 @@ try:
     # Import schemas from the docuchango package
     from docuchango.schemas import (
         ADRFrontmatter,
-        DocTypeConfig,
         DocsProjectConfig,
         GenericDocFrontmatter,
         MemoFrontmatter,
@@ -137,7 +136,7 @@ class DocValidator:
         self.errors: list[str] = []
 
         # Load project configuration
-        self.project_config_path: Path | None = None
+        self.project_config_path: Optional[Path] = None
         self.project_config = self._load_project_config()
 
     def _load_project_config(self) -> Optional[DocsProjectConfig]:
@@ -204,10 +203,10 @@ class DocValidator:
         # Default folders to scan (includes prd now!)
         return ["adr", "rfcs", "memos", "prd"]
 
-    def _build_scan_entries(self) -> list[tuple[str, str, str, bool, Path]]:
+    def _build_scan_entries(self) -> list[tuple[str, str, str, bool, bool, Path]]:
         """Build scan entries as tuples:
 
-        (doc_type, folder_relative, filename_pattern, enforce_filename_pattern, root_path)
+        (doc_type, folder_relative, filename_pattern, enforce_filename_pattern, require_frontmatter, root_path)
         """
         default_patterns = {
             "adr": r"^(adr)-(\d{3})-(.+)\.md$",
@@ -220,17 +219,24 @@ class DocValidator:
 
         if self.project_config and self.project_config.structure and self.project_config.structure.doc_types:
             roots = self.project_config.structure.docs_roots or ["."]
-            entries: list[tuple[str, str, str, bool, Path]] = []
+            entries: list[tuple[str, str, str, bool, bool, Path]] = []
 
             for doc_type_name, cfg in self.project_config.structure.doc_types.items():
-                if not isinstance(cfg, DocTypeConfig):
-                    continue
                 pattern = cfg.filename_pattern or default_patterns.get(doc_type_name, r"^(.+)\.md$")
                 folders = cfg.folders or []
                 for root_rel in roots:
                     root_path = (config_base / root_rel).resolve()
                     for folder in folders:
-                        entries.append((cfg.frontmatter_schema, folder, pattern, cfg.enforce_filename_pattern, root_path))
+                        entries.append(
+                            (
+                                cfg.frontmatter_schema,
+                                folder,
+                                pattern,
+                                cfg.enforce_filename_pattern,
+                                cfg.require_frontmatter,
+                                root_path,
+                            )
+                        )
             return entries
 
         # Legacy behavior
@@ -241,11 +247,17 @@ class DocValidator:
         for key, schema_name in [("adr", "adr"), ("rfc", "rfc"), ("memo", "memo"), ("prd", "prd")]:
             folder_name = folder_config[key]
             if folder_name in document_folders:
-                entries.append((schema_name, folder_name, default_patterns[schema_name], True, config_base))
+                entries.append((schema_name, folder_name, default_patterns[schema_name], True, True, config_base))
         return entries
 
     def _scan_document_folder(
-        self, folder_path: Path, folder_name: str, doc_type: str, pattern: re.Pattern[str], enforce_filename_pattern: bool
+        self,
+        folder_path: Path,
+        _folder_name: str,
+        doc_type: str,
+        pattern: re.Pattern[str],
+        enforce_filename_pattern: bool,
+        require_frontmatter: bool,
     ):
         """Scan a specific document folder for markdown files"""
         if not folder_path.exists():
@@ -259,9 +271,7 @@ class DocValidator:
 
             match = pattern.match(md_file.name)
             if enforce_filename_pattern and not match:
-                self.errors.append(
-                    f"Invalid {doc_type.upper()} filename: {md_file.name} (pattern: {pattern.pattern})"
-                )
+                self.errors.append(f"Invalid {doc_type.upper()} filename: {md_file.name} (pattern: {pattern.pattern})")
                 self.log(f"   ✗ {md_file.name}: Invalid filename format")
                 continue
 
@@ -272,7 +282,7 @@ class DocValidator:
                     self.log(f"   ⊘ {md_file.name}: Skipping template file")
                     continue
 
-            doc = self._parse_document(md_file, doc_type)
+            doc = self._parse_document(md_file, doc_type, require_frontmatter=require_frontmatter)
             if doc:
                 self.documents.append(doc)
                 self.file_to_doc[md_file] = doc
@@ -285,7 +295,7 @@ class DocValidator:
         if not entries:
             self.log("   ⊘ No configured scan entries found", force=True)
 
-        for doc_type, folder_name, pattern_text, enforce_pattern, root_path in entries:
+        for doc_type, folder_name, pattern_text, enforce_pattern, require_frontmatter, root_path in entries:
             try:
                 pattern = re.compile(pattern_text)
             except re.error as e:
@@ -294,12 +304,21 @@ class DocValidator:
 
             folder_path = (root_path / folder_name).resolve()
             self.log(f"   Scanning {folder_path} ({doc_type} documents)...")
-            self._scan_document_folder(folder_path, folder_name, doc_type, pattern, enforce_pattern)
+            self._scan_document_folder(
+                folder_path,
+                folder_name,
+                doc_type,
+                pattern,
+                enforce_pattern,
+                require_frontmatter,
+            )
 
         # Scan general docs markdown files at docs roots
         roots_to_scan = [self._get_config_base_dir()]
         if self.project_config and self.project_config.structure:
-            roots_to_scan = [(self._get_config_base_dir() / p).resolve() for p in self.project_config.structure.docs_roots]
+            roots_to_scan = [
+                (self._get_config_base_dir() / p).resolve() for p in self.project_config.structure.docs_roots
+            ]
 
         for docs_dir in roots_to_scan:
             if not docs_dir.exists():
@@ -314,11 +333,21 @@ class DocValidator:
 
         self.log(f"   Found {len(self.documents)} documents")
 
-    def _parse_document(self, file_path: Path, doc_type: str) -> Optional[Document]:
+    def _parse_document(self, file_path: Path, doc_type: str, require_frontmatter: bool = True) -> Optional[Document]:
         """Parse a markdown file and validate frontmatter"""
-        return self._parse_document_enhanced(file_path, doc_type)
+        return self._parse_document_enhanced(file_path, doc_type, require_frontmatter=require_frontmatter)
 
-    def _parse_document_enhanced(self, file_path: Path, doc_type: str) -> Optional[Document]:
+    def _infer_plain_markdown_title(self, file_path: Path, content: str) -> str:
+        """Infer a title for plain-markdown generic documents."""
+        for line in content.splitlines():
+            stripped = line.strip()
+            if stripped.startswith("# "):
+                return stripped[2:].strip()
+        return file_path.stem.replace("-", " ").replace("_", " ").strip().title() or file_path.name
+
+    def _parse_document_enhanced(
+        self, file_path: Path, doc_type: str, require_frontmatter: bool = True
+    ) -> Optional[Document]:
         """Parse document with python-frontmatter and pydantic validation"""
         try:
             # Read file content once and cache it
@@ -328,6 +357,11 @@ class DocValidator:
             post = frontmatter.loads(content)
 
             if not post.metadata:
+                if doc_type == "generic" and not require_frontmatter:
+                    title = self._infer_plain_markdown_title(file_path, content)
+                    self.log(f"   ✓ {file_path.name}: Plain Markdown generic doc")
+                    return Document(file_path=file_path, doc_type=doc_type, title=title, _content_cache=content)
+
                 error = "Missing YAML frontmatter"
                 self.log(f"   ✗ {file_path.name}: {error}")
                 doc = Document(file_path=file_path, doc_type=doc_type, title="Unknown", _content_cache=content)

--- a/tests/test_config_loading.py
+++ b/tests/test_config_loading.py
@@ -336,3 +336,149 @@ Test PRD content.
             # But "adr" and "prd" should be
             assert "adr" in folder_to_types
             assert "prd" in folder_to_types
+
+    def test_load_config_from_repo_root(self):
+        """Validator should load docs-project.yaml from repo root when present."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo_root = Path(tmpdir)
+            config_data = {
+                "project": {
+                    "id": "root-config-project",
+                    "name": "Root Config Project",
+                },
+                "structure": {
+                    "document_folders": ["adr"],
+                },
+            }
+
+            config_path = repo_root / "docs-project.yaml"
+            with config_path.open("w") as f:
+                yaml.dump(config_data, f)
+
+            validator = DocValidator(repo_root, verbose=False)
+            assert validator.project_config is not None
+            assert validator.project_config.project.id == "root-config-project"
+
+    def test_doc_types_custom_layout_mixed_schema(self):
+        """Custom doc_types should support mixed folders and schema bindings."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo_root = Path(tmpdir)
+            docs_root = repo_root / "docs"
+            docs_root.mkdir(parents=True)
+
+            # Mixed layout: numbered ADR, non-numbered PRFAQ
+            (docs_root / "adr").mkdir()
+            (docs_root / "prfaq").mkdir()
+
+            (docs_root / "adr" / "adr-001-test.md").write_text(
+                """---
+title: Test ADR Decision
+status: Accepted
+created: 2025-01-01
+deciders: Core Team
+tags: [architecture]
+id: adr-001
+project_id: mixed-project
+doc_uuid: 12345678-1234-4123-8123-123456789abc
+---
+
+# ADR content
+"""
+            )
+
+            (docs_root / "prfaq" / "prfaq-why-now.md").write_text(
+                """---
+title: Why now
+project_id: mixed-project
+doc_uuid: 87654321-4321-4321-8321-210987654321
+tags: [product]
+---
+
+# PRFAQ content
+"""
+            )
+
+            config_data = {
+                "project": {
+                    "id": "mixed-project",
+                    "name": "Mixed Project",
+                },
+                "structure": {
+                    "docs_roots": ["docs"],
+                    "doc_types": {
+                        "adr": {
+                            "schema": "adr",
+                            "folders": ["adr"],
+                            "filename_pattern": r"^(adr)-(\d{3})-(.+)\.md$",
+                            "enforce_filename_pattern": True,
+                        },
+                        "prfaq": {
+                            "schema": "generic",
+                            "folders": ["prfaq"],
+                            "filename_pattern": r"^prfaq-.+\.md$",
+                            "enforce_filename_pattern": True,
+                        },
+                    },
+                },
+            }
+
+            config_path = repo_root / "docs-project.yaml"
+            with config_path.open("w") as f:
+                yaml.dump(config_data, f)
+
+            validator = DocValidator(repo_root, verbose=False)
+            validator.scan_documents()
+
+            # ADR + PRFAQ should both be discovered
+            names = sorted(d.file_path.name for d in validator.documents)
+            assert "adr-001-test.md" in names
+            assert "prfaq-why-now.md" in names
+
+    def test_doc_types_can_disable_filename_enforcement(self):
+        """Custom doc_types can disable strict filename enforcement."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo_root = Path(tmpdir)
+            docs_root = repo_root / "docs"
+            docs_root.mkdir(parents=True)
+            (docs_root / "notes").mkdir()
+
+            # Doesn't match strict numeric pattern but should pass when enforcement is disabled
+            (docs_root / "notes" / "draft-about-capacity.md").write_text(
+                """---
+title: Capacity Notes
+project_id: mixed-project
+doc_uuid: 11111111-1111-4111-8111-111111111111
+---
+
+# Notes
+"""
+            )
+
+            config_data = {
+                "project": {
+                    "id": "mixed-project",
+                    "name": "Mixed Project",
+                },
+                "structure": {
+                    "docs_roots": ["docs"],
+                    "doc_types": {
+                        "notes": {
+                            "schema": "generic",
+                            "folders": ["notes"],
+                            "filename_pattern": r"^note-(\d+)\.md$",
+                            "enforce_filename_pattern": False,
+                        }
+                    },
+                },
+            }
+
+            config_path = repo_root / "docs-project.yaml"
+            with config_path.open("w") as f:
+                yaml.dump(config_data, f)
+
+            validator = DocValidator(repo_root, verbose=False)
+            validator.scan_documents()
+
+            names = [d.file_path.name for d in validator.documents]
+            assert "draft-about-capacity.md" in names
+            assert not any("Invalid" in err for err in validator.errors)

--- a/tests/test_config_loading.py
+++ b/tests/test_config_loading.py
@@ -482,3 +482,98 @@ doc_uuid: 11111111-1111-4111-8111-111111111111
             names = [d.file_path.name for d in validator.documents]
             assert "draft-about-capacity.md" in names
             assert not any("Invalid" in err for err in validator.errors)
+
+    def test_generic_doc_types_can_allow_plain_markdown_without_frontmatter(self):
+        """Generic lanes can opt into plain markdown without YAML frontmatter."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo_root = Path(tmpdir)
+            docs_root = repo_root / "docs"
+            docs_root.mkdir(parents=True)
+            (docs_root / "design").mkdir()
+
+            doc_path = docs_root / "design" / "plain-design-note.md"
+            doc_path.write_text(
+                """# Plain Design Note
+
+This lane intentionally uses plain markdown without frontmatter.
+
+```text
+Example block
+```
+"""
+            )
+
+            config_data = {
+                "project": {
+                    "id": "mixed-project",
+                    "name": "Mixed Project",
+                },
+                "structure": {
+                    "docs_roots": ["docs"],
+                    "doc_types": {
+                        "design-notes": {
+                            "schema": "generic",
+                            "folders": ["design"],
+                            "filename_pattern": r".+\.md$",
+                            "enforce_filename_pattern": False,
+                            "require_frontmatter": False,
+                        }
+                    },
+                },
+            }
+
+            config_path = repo_root / "docs-project.yaml"
+            with config_path.open("w") as f:
+                yaml.dump(config_data, f)
+
+            validator = DocValidator(repo_root, verbose=False)
+            validator.scan_documents()
+
+            assert len(validator.documents) == 1
+            doc = validator.documents[0]
+            assert doc.file_path.name == "plain-design-note.md"
+            assert doc.title == "Plain Design Note"
+            assert doc.errors == []
+
+    def test_generic_doc_types_still_require_frontmatter_by_default(self):
+        """Generic lanes stay strict unless require_frontmatter is disabled."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo_root = Path(tmpdir)
+            docs_root = repo_root / "docs"
+            docs_root.mkdir(parents=True)
+            (docs_root / "design").mkdir()
+
+            (docs_root / "design" / "strict-design-note.md").write_text(
+                """# Strict Design Note
+
+This document omits frontmatter and should still fail by default.
+"""
+            )
+
+            config_data = {
+                "project": {
+                    "id": "mixed-project",
+                    "name": "Mixed Project",
+                },
+                "structure": {
+                    "docs_roots": ["docs"],
+                    "doc_types": {
+                        "design-notes": {
+                            "schema": "generic",
+                            "folders": ["design"],
+                            "filename_pattern": r".+\.md$",
+                            "enforce_filename_pattern": False,
+                        }
+                    },
+                },
+            }
+
+            config_path = repo_root / "docs-project.yaml"
+            with config_path.open("w") as f:
+                yaml.dump(config_data, f)
+
+            validator = DocValidator(repo_root, verbose=False)
+            validator.scan_documents()
+
+            assert len(validator.documents) == 1
+            assert validator.documents[0].errors == ["Missing YAML frontmatter"]


### PR DESCRIPTION
## Summary
- add `require_frontmatter` for mixed-schema `doc_types` so generic lanes can explicitly allow plain Markdown without YAML frontmatter
- keep generic validation strict by default, while documenting the opt-in config needed for monorepos that mix strict and plain-Markdown document lanes
- add regression tests plus docs/template guidance for the new compatibility mode

## Validation
- `uv run pytest tests/test_config_loading.py tests/test_schemas.py tests/test_validator.py tests/test_cli_commands.py -q` (64 passed)
- manually confirmed the new behavior is available for generic lanes that opt in via `require_frontmatter: false`

## Notes
- left unrelated local `uv.lock` change unstaged and out of this PR