### PR TITLE
feat: compress document ids

### DIFF
--- a/docuchango/cli.py
+++ b/docuchango/cli.py
@@ -58,6 +58,21 @@ def _discover_doc_files(root: Path) -> list[Path]:
                             files.append(file_path)
         return sorted(files)
 
+    if config and config.structure and config_path:
+        config_base = config_path.parent
+        files = []
+        seen = set()
+        for folder in config.structure.document_folders:
+            folder_path = (config_base / folder).resolve()
+            if not folder_path.exists():
+                continue
+            for file_path in folder_path.rglob("*.md"):
+                if file_path not in seen:
+                    seen.add(file_path)
+                    files.append(file_path)
+        if files:
+            return sorted(files)
+
     # Legacy mode (backwards compatibility)
     doc_patterns = [
         "adr/**/*.md",
@@ -780,6 +795,120 @@ def bulk_timestamps(
         console.print(f"[green]Modified {modified_count} of {len(all_files)} files[/green]")
         if error_count:
             console.print(f"[red]Errors: {error_count}[/red]")
+
+
+@bulk.command("compress-ids")
+@click.option(
+    "--type",
+    "doc_type",
+    type=click.Choice(["adr", "rfc", "memo", "prd"]),
+    help="Filter by document type",
+)
+@click.option(
+    "--path",
+    "target_path",
+    type=click.Path(exists=True, path_type=Path),
+    help="Repository or docs root (default: current directory)",
+)
+@click.option("--dry-run", is_flag=True, help="Preview changes without applying")
+@click.option("--verbose", "-v", is_flag=True, help="Show detailed output")
+def bulk_compress_ids(
+    doc_type: str | None,
+    target_path: Path | None,
+    dry_run: bool,
+    verbose: bool,
+):
+    """Compress document IDs and update references.
+
+    Renumbers documents of each selected type into a contiguous sequence while
+    preserving filename suffixes. References across the repository are rewritten,
+    then an audit reports stale or missing document-like references.
+
+    Examples:
+
+        \b
+        # Compress all document types
+        docuchango bulk compress-ids
+
+        \b
+        # Compress only memos: memo-001, memo-010 -> memo-001, memo-002
+        docuchango bulk compress-ids --type memo
+
+        \b
+        # Preview all renames and reference updates
+        docuchango bulk compress-ids --dry-run --verbose
+    """
+    from docuchango.fixes.id_compression import compress_document_ids
+
+    root = target_path or Path.cwd()
+    discovered_files = _discover_doc_files(root)
+    all_files = _filter_files_by_doc_type(discovered_files, doc_type)
+
+    if not all_files:
+        console.print("[yellow]No files found matching criteria[/yellow]")
+        sys.exit(0)
+
+    console.print("[bold blue]🗜️  Compressing document IDs[/bold blue]")
+    if dry_run:
+        console.print("[yellow]DRY RUN - No changes will be made[/yellow]")
+    console.print(f"Processing {len(all_files)} files...\n")
+
+    try:
+        result = compress_document_ids(root, discovered_files, doc_type=doc_type, dry_run=dry_run)
+    except Exception as e:
+        console.print(f"[red]✗[/red] {e}")
+        sys.exit(1)
+
+    action = "Would renumber" if dry_run else "Renumbered"
+    if result.changes:
+        console.print(f"[green]{action} {len(result.changes)} document(s)[/green]")
+        for change in result.changes:
+            old_rel = change.file_path.relative_to(root)
+            new_rel = change.new_path.relative_to(root)
+            console.print(f"  {change.old_id} → {change.new_id}: {old_rel} → {new_rel}")
+    else:
+        console.print("[green]Document IDs are already contiguous[/green]")
+
+    if result.updated_files:
+        action = "Would update" if dry_run else "Updated"
+        console.print(f"\n[green]{action} references in {len(result.updated_files)} file(s)[/green]")
+        if verbose:
+            for file_path, count in sorted(result.updated_files.items()):
+                rel_path = file_path.relative_to(root)
+                console.print(f"  {rel_path}: {count} change(s)")
+    else:
+        console.print("\n[green]No references needed updates[/green]")
+
+    if result.synced_files:
+        action = "Would sync" if dry_run else "Synced"
+        console.print(f"\n[green]{action} frontmatter IDs in {len(result.synced_files)} file(s)[/green]")
+        if verbose:
+            for file_path in result.synced_files:
+                rel_path = file_path.relative_to(root)
+                console.print(f"  {rel_path}")
+
+    if result.stale_references:
+        console.print(f"\n[red]Stale references after rewrite: {len(result.stale_references)}[/red]")
+        for hit in result.stale_references[:25]:
+            rel_path = hit.file_path.relative_to(root)
+            console.print(f"  {rel_path}:{hit.line_number}: {hit.reference}")
+        if len(result.stale_references) > 25:
+            console.print(f"  ... and {len(result.stale_references) - 25} more")
+    else:
+        console.print("\n[green]No stale references to old IDs found[/green]")
+
+    if result.missing_references:
+        console.print(f"\n[yellow]Missing document references found: {len(result.missing_references)}[/yellow]")
+        for hit in result.missing_references[:25]:
+            rel_path = hit.file_path.relative_to(root)
+            console.print(f"  {rel_path}:{hit.line_number}: {hit.reference}")
+        if len(result.missing_references) > 25:
+            console.print(f"  ... and {len(result.missing_references) - 25} more")
+    elif verbose:
+        console.print("\n[green]No missing document references found[/green]")
+
+    if dry_run and (result.changes or result.updated_files):
+        console.print("\n[dim]Run without --dry-run to apply changes[/dim]")
 
 
 @main.command("migrate")

--- a/docuchango/fixes/id_compression.py
+++ b/docuchango/fixes/id_compression.py
@@ -1,0 +1,319 @@
+"""Compress document IDs and update references across a repository."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import frontmatter
+
+from docuchango.fixes.yaml_utils import dumps as frontmatter_dumps
+
+DOC_ID_RE = re.compile(r"\b(adr|rfc|memo|prd)-(\d{3})\b", re.IGNORECASE)
+FILENAME_ID_RE = re.compile(r"^(adr|rfc|memo|prd)-(\d{3})(-.+)?\.md$", re.IGNORECASE)
+
+TEXT_EXTENSIONS = {
+    ".css",
+    ".html",
+    ".js",
+    ".json",
+    ".jsx",
+    ".md",
+    ".mdx",
+    ".py",
+    ".rst",
+    ".toml",
+    ".ts",
+    ".tsx",
+    ".txt",
+    ".yaml",
+    ".yml",
+}
+SKIP_DIRS = {
+    ".git",
+    ".mypy_cache",
+    ".pytest_cache",
+    ".ruff_cache",
+    ".venv",
+    "__pycache__",
+    "htmlcov",
+    "node_modules",
+    "venv",
+}
+
+
+@dataclass(frozen=True)
+class DocumentIdChange:
+    """A planned document ID and filename change."""
+
+    file_path: Path
+    new_path: Path
+    old_id: str
+    new_id: str
+
+
+@dataclass(frozen=True)
+class ReferenceHit:
+    """A reference found during stale-reference audit."""
+
+    file_path: Path
+    line_number: int
+    reference: str
+
+
+@dataclass
+class CompressionResult:
+    """Result of a document ID compression run."""
+
+    changes: list[DocumentIdChange] = field(default_factory=list)
+    updated_files: dict[Path, int] = field(default_factory=dict)
+    synced_files: list[Path] = field(default_factory=list)
+    stale_references: list[ReferenceHit] = field(default_factory=list)
+    missing_references: list[ReferenceHit] = field(default_factory=list)
+
+
+def compress_document_ids(
+    repo_root: Path,
+    doc_files: list[Path],
+    doc_type: str | None = None,
+    dry_run: bool = False,
+) -> CompressionResult:
+    """Compress document IDs and rewrite references across the repository.
+
+    Documents are compressed independently per type. For example, memo IDs
+    001, 010, and 011 become 001, 002, and 003 while preserving each filename's
+    descriptive suffix.
+    """
+    repo_root = repo_root.resolve()
+    changes = _plan_id_changes(doc_files, doc_type)
+    result = CompressionResult(changes=changes)
+
+    updated_files = _rewrite_references(repo_root, changes, dry_run=dry_run)
+    result.updated_files = updated_files
+
+    if not dry_run:
+        _apply_document_changes(changes)
+
+    result.synced_files = _sync_frontmatter_ids(doc_files, changes, dry_run=dry_run)
+    result.stale_references = _audit_old_references(repo_root, changes, planned_updates=updated_files if dry_run else None)
+    result.missing_references = audit_missing_document_references(repo_root, doc_files, planned_changes=changes)
+    return result
+
+
+def audit_missing_document_references(
+    repo_root: Path,
+    doc_files: list[Path],
+    planned_changes: list[DocumentIdChange] | None = None,
+) -> list[ReferenceHit]:
+    """Find document-like references that do not resolve to a current document ID."""
+    current_ids = {_document_id_for_file(path) for path in doc_files}
+    current_ids.discard(None)
+
+    for change in planned_changes or []:
+        current_ids.discard(change.old_id)
+        current_ids.add(change.new_id)
+
+    id_map = {change.old_id: change.new_id for change in planned_changes or []}
+    missing: list[ReferenceHit] = []
+    for file_path in _iter_text_files(repo_root):
+        content = _read_text(file_path)
+        if content is None:
+            continue
+        if id_map:
+            content = _replace_ids(content, id_map)
+        for line_number, line in enumerate(content.splitlines(), start=1):
+            for match in DOC_ID_RE.finditer(line):
+                reference = match.group(0).lower()
+                if reference.endswith("-000"):
+                    continue
+                if reference not in current_ids:
+                    missing.append(ReferenceHit(file_path=file_path, line_number=line_number, reference=match.group(0)))
+    return missing
+
+
+def _plan_id_changes(doc_files: list[Path], doc_type: str | None) -> list[DocumentIdChange]:
+    docs_by_type: dict[str, list[tuple[int, Path, str]]] = {}
+    for file_path in doc_files:
+        old_id = _document_id_for_file(file_path)
+        if not old_id:
+            continue
+        prefix, number_text = old_id.split("-", 1)
+        if doc_type and prefix != doc_type:
+            continue
+        docs_by_type.setdefault(prefix, []).append((int(number_text), file_path, old_id))
+
+    changes: list[DocumentIdChange] = []
+    for prefix, docs in sorted(docs_by_type.items()):
+        for new_number, (_old_number, file_path, old_id) in enumerate(sorted(docs), start=1):
+            new_id = f"{prefix}-{new_number:03d}"
+            if new_id == old_id:
+                continue
+
+            match = FILENAME_ID_RE.match(file_path.name)
+            suffix = match.group(3) if match else f"-{file_path.stem}"
+            new_path = file_path.with_name(f"{new_id}{suffix}.md")
+            changes.append(DocumentIdChange(file_path=file_path, new_path=new_path, old_id=old_id, new_id=new_id))
+    return changes
+
+
+def _apply_document_changes(changes: list[DocumentIdChange]) -> None:
+    for change in changes:
+        _set_frontmatter_id(change.file_path, change.new_id)
+        if change.file_path == change.new_path:
+            continue
+        if change.new_path.exists():
+            raise FileExistsError(f"Cannot rename {change.file_path} to {change.new_path}: destination exists")
+        change.file_path.rename(change.new_path)
+
+
+def _sync_frontmatter_ids(
+    doc_files: list[Path], changes: list[DocumentIdChange], dry_run: bool
+) -> list[Path]:
+    current_paths = {change.new_path if change.new_path.exists() else change.file_path for change in changes}
+    changed_paths = {change.file_path for change in changes}
+    current_paths.update(path for path in doc_files if path not in changed_paths)
+
+    synced: list[Path] = []
+    for file_path in current_paths:
+        filename_id = _filename_id(file_path)
+        if not filename_id or not file_path.exists():
+            continue
+
+        try:
+            post = frontmatter.load(file_path)
+        except Exception:  # noqa: S112 - malformed docs are ignored by this repair pass
+            continue
+        if post.metadata.get("id") == filename_id:
+            continue
+
+        synced.append(file_path)
+        if not dry_run:
+            _set_frontmatter_id(file_path, filename_id)
+    return sorted(synced)
+
+
+def _rewrite_references(repo_root: Path, changes: list[DocumentIdChange], dry_run: bool) -> dict[Path, int]:
+    if not changes:
+        return {}
+
+    id_map = {change.old_id: change.new_id for change in changes}
+    filename_map = {change.file_path.name: change.new_path.name for change in changes if change.file_path.name != change.new_path.name}
+    updated_files: dict[Path, int] = {}
+
+    for file_path in _iter_text_files(repo_root):
+        content = _read_text(file_path)
+        if content is None:
+            continue
+
+        new_content = content
+        for old_name, new_name in filename_map.items():
+            new_content = new_content.replace(old_name, new_name)
+        new_content = _replace_ids(new_content, id_map)
+
+        if new_content != content:
+            updated_files[file_path] = _count_reference_updates(content, id_map, filename_map)
+            if not dry_run:
+                file_path.write_text(new_content, encoding="utf-8")
+
+    return updated_files
+
+
+def _replace_ids(content: str, id_map: dict[str, str]) -> str:
+    lowered_map = {old.lower(): new.lower() for old, new in id_map.items()}
+
+    def replace_match(match: re.Match[str]) -> str:
+        old = match.group(0)
+        new = lowered_map.get(old.lower())
+        if not new:
+            return old
+        prefix, number = new.split("-", 1)
+        old_prefix = old.split("-", 1)[0]
+        if old_prefix.isupper():
+            prefix = prefix.upper()
+        elif old_prefix[:1].isupper():
+            prefix = prefix.capitalize()
+        return f"{prefix}-{number}"
+
+    return DOC_ID_RE.sub(replace_match, content)
+
+
+def _count_reference_updates(content: str, id_map: dict[str, str], filename_map: dict[str, str]) -> int:
+    count = 0
+    old_ids = set(id_map)
+    for match in DOC_ID_RE.finditer(content):
+        if match.group(0).lower() in old_ids:
+            count += 1
+    for old_name in filename_map:
+        count += content.count(old_name)
+    return max(1, count)
+
+
+def _audit_old_references(
+    repo_root: Path,
+    changes: list[DocumentIdChange],
+    planned_updates: dict[Path, int] | None = None,
+) -> list[ReferenceHit]:
+    old_ids = {change.old_id for change in changes} - {change.new_id for change in changes}
+    if not old_ids:
+        return []
+
+    stale: list[ReferenceHit] = []
+    for file_path in _iter_text_files(repo_root):
+        content = _read_text(file_path)
+        if content is None:
+            continue
+        if planned_updates and file_path in planned_updates:
+            content = _replace_ids(content, {change.old_id: change.new_id for change in changes})
+        for line_number, line in enumerate(content.splitlines(), start=1):
+            for match in DOC_ID_RE.finditer(line):
+                if match.group(0).lower() in old_ids:
+                    stale.append(ReferenceHit(file_path=file_path, line_number=line_number, reference=match.group(0)))
+    return stale
+
+
+def _document_id_for_file(file_path: Path) -> str | None:
+    filename_id = _filename_id(file_path)
+    if filename_id:
+        return filename_id
+
+    try:
+        post = frontmatter.load(file_path)
+    except Exception:
+        post = None
+    if post and isinstance(post.metadata.get("id"), str):
+        metadata_id = post.metadata["id"].lower()
+        if DOC_ID_RE.fullmatch(metadata_id):
+            return metadata_id
+
+    return None
+
+
+def _filename_id(file_path: Path) -> str | None:
+    match = FILENAME_ID_RE.match(file_path.name)
+    if not match:
+        return None
+    return f"{match.group(1).lower()}-{match.group(2)}"
+
+
+def _set_frontmatter_id(file_path: Path, doc_id: str) -> None:
+    content = file_path.read_text(encoding="utf-8")
+    post = frontmatter.loads(content)
+    post.metadata["id"] = doc_id
+    file_path.write_text(frontmatter_dumps(post), encoding="utf-8")
+
+
+def _iter_text_files(repo_root: Path):  # type: ignore[no-untyped-def]
+    for path in repo_root.rglob("*"):
+        if any(part in SKIP_DIRS for part in path.parts):
+            continue
+        if not path.is_file() or path.suffix.lower() not in TEXT_EXTENSIONS:
+            continue
+        yield path
+
+
+def _read_text(file_path: Path) -> str | None:
+    try:
+        return file_path.read_text(encoding="utf-8")
+    except UnicodeDecodeError:
+        return None

--- a/docuchango/fixes/id_compression.py
+++ b/docuchango/fixes/id_compression.py
@@ -96,7 +96,9 @@ def compress_document_ids(
         _apply_document_changes(changes)
 
     result.synced_files = _sync_frontmatter_ids(doc_files, changes, dry_run=dry_run)
-    result.stale_references = _audit_old_references(repo_root, changes, planned_updates=updated_files if dry_run else None)
+    result.stale_references = _audit_old_references(
+        repo_root, changes, planned_updates=updated_files if dry_run else None
+    )
     result.missing_references = audit_missing_document_references(repo_root, doc_files, planned_changes=changes)
     return result
 
@@ -167,9 +169,7 @@ def _apply_document_changes(changes: list[DocumentIdChange]) -> None:
         change.file_path.rename(change.new_path)
 
 
-def _sync_frontmatter_ids(
-    doc_files: list[Path], changes: list[DocumentIdChange], dry_run: bool
-) -> list[Path]:
+def _sync_frontmatter_ids(doc_files: list[Path], changes: list[DocumentIdChange], dry_run: bool) -> list[Path]:
     current_paths = {change.new_path if change.new_path.exists() else change.file_path for change in changes}
     changed_paths = {change.file_path for change in changes}
     current_paths.update(path for path in doc_files if path not in changed_paths)
@@ -198,7 +198,11 @@ def _rewrite_references(repo_root: Path, changes: list[DocumentIdChange], dry_ru
         return {}
 
     id_map = {change.old_id: change.new_id for change in changes}
-    filename_map = {change.file_path.name: change.new_path.name for change in changes if change.file_path.name != change.new_path.name}
+    filename_map = {
+        change.file_path.name: change.new_path.name
+        for change in changes
+        if change.file_path.name != change.new_path.name
+    }
     updated_files: dict[Path, int] = {}
 
     for file_path in _iter_text_files(repo_root):

--- a/tests/test_id_compression.py
+++ b/tests/test_id_compression.py
@@ -1,0 +1,153 @@
+"""Tests for document ID compression."""
+
+from click.testing import CliRunner
+
+from docuchango.cli import main
+from docuchango.fixes.id_compression import audit_missing_document_references, compress_document_ids
+
+
+def _write_memo(path, memo_id: str, title: str, body: str = ""):
+    path.write_text(
+        f"""---
+id: {memo_id}
+title: {title}
+status: Draft
+created: 2026-01-01T00:00:00Z
+author: Test User
+tags: []
+---
+
+# {title}
+
+{body}
+""",
+        encoding="utf-8",
+    )
+
+
+def test_compress_document_ids_renames_files_and_updates_references(tmp_path):
+    memos_dir = tmp_path / "memos"
+    memos_dir.mkdir()
+
+    memo_001 = memos_dir / "memo-001-first.md"
+    memo_010 = memos_dir / "memo-010-second.md"
+    memo_011 = memos_dir / "memo-011-third.md"
+    _write_memo(memo_001, "memo-001", "First Memo")
+    _write_memo(memo_010, "memo-010", "Second Memo", "References MEMO-011 and /memos/memo-001.")
+    _write_memo(memo_011, "memo-011", "Third Memo")
+
+    readme = tmp_path / "README.md"
+    readme.write_text(
+        "See [second](memos/memo-010-second.md), [third](/memos/MEMO-011), and memo-010.",
+        encoding="utf-8",
+    )
+
+    result = compress_document_ids(tmp_path, [memo_001, memo_010, memo_011], doc_type="memo")
+
+    assert [(change.old_id, change.new_id) for change in result.changes] == [
+        ("memo-010", "memo-002"),
+        ("memo-011", "memo-003"),
+    ]
+    assert not memo_010.exists()
+    assert not memo_011.exists()
+    assert (memos_dir / "memo-002-second.md").exists()
+    assert (memos_dir / "memo-003-third.md").exists()
+
+    second_content = (memos_dir / "memo-002-second.md").read_text(encoding="utf-8")
+    assert "id: memo-002" in second_content
+    assert "MEMO-003" in second_content
+    assert "memo-010" not in second_content
+
+    readme_content = readme.read_text(encoding="utf-8")
+    assert "memos/memo-002-second.md" in readme_content
+    assert "/memos/MEMO-003" in readme_content
+    assert "memo-002" in readme_content
+    assert "memo-010" not in readme_content
+    assert result.stale_references == []
+
+
+def test_compress_document_ids_preserves_new_id_when_it_was_an_old_id(tmp_path):
+    adr_dir = tmp_path / "adr"
+    adr_dir.mkdir()
+
+    adr_001 = adr_dir / "adr-001-first.md"
+    adr_003 = adr_dir / "adr-003-second.md"
+    adr_032 = adr_dir / "adr-032-third.md"
+    _write_memo(adr_001, "adr-001", "First ADR")
+    _write_memo(adr_003, "adr-003", "Second ADR")
+    _write_memo(adr_032, "adr-032", "Third ADR", "References ADR-003 and ADR-032.")
+
+    result = compress_document_ids(tmp_path, [adr_001, adr_003, adr_032], doc_type="adr")
+
+    assert [(change.old_id, change.new_id) for change in result.changes] == [
+        ("adr-003", "adr-002"),
+        ("adr-032", "adr-003"),
+    ]
+    new_third = adr_dir / "adr-003-third.md"
+    assert new_third.exists()
+    new_third_content = new_third.read_text(encoding="utf-8")
+    assert "id: adr-003" in new_third_content
+    assert "ADR-002 and ADR-003" in new_third_content
+
+
+def test_compress_document_ids_syncs_frontmatter_to_filename(tmp_path):
+    memos_dir = tmp_path / "memos"
+    memos_dir.mkdir()
+
+    memo_001 = memos_dir / "memo-001-first.md"
+    _write_memo(memo_001, "memo-999", "First Memo")
+
+    result = compress_document_ids(tmp_path, [memo_001], doc_type="memo")
+
+    assert result.changes == []
+    assert result.synced_files == [memo_001]
+    assert "id: memo-001" in memo_001.read_text(encoding="utf-8")
+
+
+def test_compress_document_ids_dry_run_does_not_modify_files(tmp_path):
+    memos_dir = tmp_path / "memos"
+    memos_dir.mkdir()
+
+    memo_001 = memos_dir / "memo-001-first.md"
+    memo_010 = memos_dir / "memo-010-second.md"
+    _write_memo(memo_001, "memo-001", "First Memo")
+    _write_memo(memo_010, "memo-010", "Second Memo")
+    original = memo_010.read_text(encoding="utf-8")
+
+    result = compress_document_ids(tmp_path, [memo_001, memo_010], doc_type="memo", dry_run=True)
+
+    assert [(change.old_id, change.new_id) for change in result.changes] == [("memo-010", "memo-002")]
+    assert memo_010.exists()
+    assert not (memos_dir / "memo-002-second.md").exists()
+    assert memo_010.read_text(encoding="utf-8") == original
+    assert result.stale_references == []
+
+
+def test_audit_missing_document_references_reports_stale_refs(tmp_path):
+    memos_dir = tmp_path / "memos"
+    memos_dir.mkdir()
+
+    memo_001 = memos_dir / "memo-001-first.md"
+    _write_memo(memo_001, "memo-001", "First Memo")
+    (tmp_path / "notes.md").write_text("memo-999 is stale\n", encoding="utf-8")
+
+    hits = audit_missing_document_references(tmp_path, [memo_001])
+
+    assert len(hits) == 1
+    assert hits[0].file_path == tmp_path / "notes.md"
+    assert hits[0].line_number == 1
+    assert hits[0].reference == "memo-999"
+
+
+def test_bulk_compress_ids_cli(tmp_path):
+    memos_dir = tmp_path / "memos"
+    memos_dir.mkdir()
+
+    _write_memo(memos_dir / "memo-001-first.md", "memo-001", "First Memo")
+    _write_memo(memos_dir / "memo-010-second.md", "memo-010", "Second Memo")
+
+    result = CliRunner().invoke(main, ["bulk", "compress-ids", "--path", str(tmp_path), "--type", "memo"])
+
+    assert result.exit_code == 0
+    assert "Renumbered 1 document" in result.output
+    assert (memos_dir / "memo-002-second.md").exists()

--- a/uv.lock
+++ b/uv.lock
@@ -282,7 +282,7 @@ toml = [
 
 [[package]]
 name = "docuchango"
-version = "1.12.2"
+version = "1.13.0"
 source = { editable = "." }
 dependencies = [
     { name = "click", version = "8.1.8", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },


### PR DESCRIPTION
## Summary
- Add `docuchango bulk compress-ids` to compact ADR/RFC/MEMO/PRD numeric IDs while preserving filename suffixes.
- Rewrite references and filenames across repository text files, then audit for stale old IDs and missing document-like references.
- Support legacy `document_folders` discovery paths and add regression coverage for simultaneous ID swap collisions and frontmatter sync repair.

## Validation
- `uv run ruff check docuchango/fixes/id_compression.py docuchango/cli.py tests/test_id_compression.py`
- `uv run pytest tests/test_id_compression.py tests/test_cli_commands.py`
- Tested against `~/hc/hermes`: 97 documents renumbered, 162 files rewritten, post-run audit reported contiguous IDs and no stale old-ID references; `docuchango validate --skip-build --dry-run` reported all documents valid.