### PR TITLE
Add configured document indexes with time and milestone bucket validation

### DIFF
--- a/docuchango/schemas.py
+++ b/docuchango/schemas.py
@@ -202,6 +202,60 @@ class DocsProjectReadability(BaseModel):
         )
 
 
+class DocsProjectIndexTimeBucket(BaseModel):
+    """Time or milestone bucket rules for a document index."""
+
+    cadence: Literal["weekly", "monthly", "quarterly", "yearly", "milestone"] = Field(
+        ...,
+        description="Bucket cadence for indexed documents",
+    )
+    field: str = Field(
+        default="created",
+        description="Target frontmatter field used to compute date buckets",
+    )
+    milestone_field: str = Field(
+        default="milestone",
+        description="Target frontmatter field used when cadence is milestone",
+    )
+    heading_level: int = Field(
+        default=2,
+        ge=1,
+        le=6,
+        description="Markdown heading level used for bucket headings",
+    )
+    heading_pattern: str | None = Field(
+        default=None,
+        description="Optional regex that bucket heading text must match",
+    )
+
+
+class DocsProjectIndex(BaseModel):
+    """Configuration for a Markdown file that indexes other repository documents."""
+
+    name: str = Field(..., min_length=1, description="Human-readable index name")
+    path: str = Field(..., min_length=1, description="Index Markdown file, relative to docs-project.yaml")
+    targets: list[str] = Field(
+        default_factory=list,
+        description="Glob patterns for Markdown files that must appear in the index",
+    )
+    require_all_targets: bool = Field(
+        default=True,
+        description="Require every target file to be linked from the index",
+    )
+    require_entries: bool = Field(
+        default=True,
+        description="Require the index to contain at least one Markdown link when targets exist",
+    )
+    allow_extra_links: bool = Field(
+        default=True,
+        description="Allow Markdown links to files outside the configured target set",
+    )
+    time_bucket: DocsProjectIndexTimeBucket | None = Field(
+        default=None,
+        description="Optional bucket discipline for release notes, milestone changelogs, and similar indexes",
+    )
+
+
 class DocsProjectConfig(BaseModel):
     """Schema for docs-project.yaml configuration file.
 
@@ -224,6 +278,10 @@ class DocsProjectConfig(BaseModel):
     readability: DocsProjectReadability = Field(
         default_factory=DocsProjectReadability,
         description="Readability analysis configuration and thresholds",
+    )
+    indexes: list[DocsProjectIndex] = Field(
+        default_factory=list,
+        description="Markdown index files with stricter content discipline",
     )
 
 

--- a/docuchango/templates/docs-project.yaml
+++ b/docuchango/templates/docs-project.yaml
@@ -42,6 +42,36 @@ structure:
   #     enforce_filename_pattern: false
   #     require_frontmatter: false  # Allow plain Markdown design notes
 
+# Optional Markdown files that index other repository files.
+# These rules are stricter than normal docs validation: targets can be required,
+# extra Markdown links can be forbidden, and release/milestone indexes can require
+# entries under time or milestone bucket headings.
+# indexes:
+#   - name: Shared Design Index
+#     path: docs/design-index.md
+#     targets:
+#       - docs/design/**/*.md
+#     require_all_targets: true
+#     require_entries: true
+#     allow_extra_links: true
+#   - name: Weekly Release Notes
+#     path: docs/release-index.md
+#     targets:
+#       - docs/release-notes/*.md
+#     time_bucket:
+#       cadence: weekly  # weekly, monthly, quarterly, yearly, or milestone
+#       field: created
+#       heading_level: 2
+#       heading_pattern: "^\\d{4}-W\\d{2}$"
+#   - name: Milestone Changelog
+#     path: docs/milestone-changelog.md
+#     targets:
+#       - docs/plans/*.md
+#     time_bucket:
+#       cadence: milestone
+#       milestone_field: milestone
+#       heading_level: 2
+
 metadata:
   created: "2025-01-01"
   maintainers:

--- a/docuchango/validator.py
+++ b/docuchango/validator.py
@@ -26,6 +26,7 @@ import re
 import subprocess
 import sys
 from dataclasses import dataclass, field
+from datetime import date, datetime
 from enum import Enum
 from pathlib import Path
 from typing import Optional
@@ -710,6 +711,178 @@ class DocValidator:
         if not issues_found:
             self.log("   ✓ No problematic cross-plugin links found")
 
+    def _extract_markdown_file_links(self, content: str, source_path: Path) -> dict[Path, tuple[int, str]]:
+        """Extract Markdown file links and resolve them to absolute paths."""
+        links: dict[Path, tuple[int, str]] = {}
+        in_code_fence = False
+        link_pattern = re.compile(r"\[([^\]]+)\]\(([^)]+)\)")
+
+        for line_num, line in enumerate(content.splitlines(), start=1):
+            if line.startswith("```"):
+                in_code_fence = not in_code_fence
+                continue
+            if in_code_fence:
+                continue
+
+            line_without_code = re.sub(r"`[^`]+`", "", line)
+            for match in link_pattern.finditer(line_without_code):
+                target = match.group(2).split("#", 1)[0]
+                if re.match(r"^[a-z][a-z0-9+.-]*:", target):
+                    continue
+                if not target.endswith(".md") and not target.startswith(("./", "../", "/")):
+                    continue
+
+                if target.startswith("/"):
+                    resolved = (self.repo_root / target.lstrip("/")).resolve()
+                else:
+                    resolved = (source_path.parent / target).resolve()
+                    if not target.endswith(".md"):
+                        resolved = Path(str(resolved) + ".md")
+                links[resolved] = (line_num, target)
+
+        return links
+
+    def _extract_bucket_headings(self, content: str, heading_level: int) -> dict[int, str]:
+        """Map line numbers to bucket heading text at the configured heading level."""
+        marker = "#" * heading_level
+        headings: dict[int, str] = {}
+        in_code_fence = False
+
+        for line_num, line in enumerate(content.splitlines(), start=1):
+            if line.startswith("```"):
+                in_code_fence = not in_code_fence
+                continue
+            if in_code_fence:
+                continue
+            if line.startswith(f"{marker} ") and not line.startswith(f"{marker}#"):
+                headings[line_num] = line[len(marker) :].strip()
+
+        return headings
+
+    def _bucket_for_target(self, target_path: Path, bucket_config) -> Optional[str]:  # type: ignore[no-untyped-def]
+        """Compute the expected index bucket for a target document."""
+        post = frontmatter.loads(target_path.read_text(encoding="utf-8"))
+
+        if bucket_config.cadence == "milestone":
+            milestone = post.metadata.get(bucket_config.milestone_field)
+            return str(milestone).strip() if milestone else None
+
+        value = post.metadata.get(bucket_config.field)
+        if isinstance(value, datetime):
+            target_date = value.date()
+        elif isinstance(value, date):
+            target_date = value
+        elif isinstance(value, str):
+            target_date = date.fromisoformat(value.split("T", 1)[0])
+        else:
+            return None
+
+        if bucket_config.cadence == "weekly":
+            iso_year, iso_week, _ = target_date.isocalendar()
+            return f"{iso_year}-W{iso_week:02d}"
+        if bucket_config.cadence == "monthly":
+            return f"{target_date:%Y-%m}"
+        if bucket_config.cadence == "quarterly":
+            quarter = ((target_date.month - 1) // 3) + 1
+            return f"{target_date.year}-Q{quarter}"
+        if bucket_config.cadence == "yearly":
+            return f"{target_date.year}"
+        return None
+
+    def check_document_indexes(self):
+        """Validate configured Markdown index files."""
+        if not self.project_config or not self.project_config.indexes:
+            return
+
+        self.log("\n🗂️  Checking document indexes...")
+        config_base = self._get_config_base_dir()
+
+        for index_config in self.project_config.indexes:
+            index_path = (config_base / index_config.path).resolve()
+            if not index_path.exists():
+                self.errors.append(f"Document index '{index_config.name}' not found: {index_config.path}")
+                continue
+
+            try:
+                content = index_path.read_text(encoding="utf-8")
+                links = self._extract_markdown_file_links(content, index_path)
+                target_paths: set[Path] = set()
+                for target_pattern in index_config.targets:
+                    target_paths.update(path.resolve() for path in config_base.glob(target_pattern) if path.is_file())
+                target_paths.discard(index_path)
+
+                if index_config.require_entries and target_paths and not links:
+                    self.errors.append(f"Document index '{index_config.name}' has no Markdown links")
+
+                if index_config.require_all_targets:
+                    for target_path in sorted(target_paths):
+                        if target_path not in links:
+                            rel_target = target_path.relative_to(config_base)
+                            self.errors.append(f"Document index '{index_config.name}' is missing target: {rel_target}")
+
+                if not index_config.allow_extra_links:
+                    for linked_path, (line_num, raw_target) in sorted(links.items()):
+                        if linked_path.exists() and linked_path not in target_paths:
+                            self.errors.append(
+                                f"Document index '{index_config.name}' line {line_num} links outside targets: {raw_target}"
+                            )
+
+                if index_config.time_bucket:
+                    self._check_document_index_buckets(index_config.name, content, links, target_paths, index_config.time_bucket)
+
+                self.log(f"   ✓ {index_config.name}: {len(target_paths)} target(s) checked")
+            except Exception as e:
+                self.errors.append(f"Error checking document index '{index_config.name}': {e}")
+
+    def _check_document_index_buckets(self, name: str, content: str, links: dict[Path, tuple[int, str]], target_paths: set[Path], bucket_config) -> None:  # type: ignore[no-untyped-def]
+        """Validate that index links appear under the expected time or milestone bucket."""
+        headings = self._extract_bucket_headings(content, bucket_config.heading_level)
+        if not headings:
+            self.errors.append(f"Document index '{name}' has no bucket headings")
+            return
+
+        if bucket_config.heading_pattern:
+            heading_re = re.compile(bucket_config.heading_pattern)
+            for line_num, heading in headings.items():
+                if not heading_re.match(heading):
+                    self.errors.append(f"Document index '{name}' line {line_num} has invalid bucket heading: {heading}")
+
+        sorted_headings = sorted(headings.items())
+        buckets = set(headings.values())
+
+        def bucket_at_line(line_num: int) -> Optional[str]:
+            current = None
+            for heading_line, heading in sorted_headings:
+                if heading_line >= line_num:
+                    break
+                current = heading
+            return current
+
+        for target_path in sorted(target_paths):
+            try:
+                expected_bucket = self._bucket_for_target(target_path, bucket_config)
+            except Exception as e:
+                rel_target = target_path.relative_to(self._get_config_base_dir())
+                self.errors.append(f"Document index '{name}' cannot read bucket for {rel_target}: {e}")
+                continue
+
+            rel_target = target_path.relative_to(self._get_config_base_dir())
+            if not expected_bucket:
+                self.errors.append(f"Document index '{name}' cannot determine bucket for {rel_target}")
+                continue
+            if expected_bucket not in buckets:
+                self.errors.append(f"Document index '{name}' missing bucket heading: {expected_bucket}")
+                continue
+            if target_path not in links:
+                continue
+
+            line_num, _ = links[target_path]
+            actual_bucket = bucket_at_line(line_num)
+            if actual_bucket != expected_bucket:
+                self.errors.append(
+                    f"Document index '{name}' links {rel_target} under '{actual_bucket}' instead of '{expected_bucket}'"
+                )
+
     def check_typescript_config(self):
         """Run TypeScript typecheck on Docusaurus config"""
         self.log("\n🔍 Running TypeScript typecheck...")
@@ -1340,6 +1513,7 @@ class DocValidator:
         self.check_mdx_compilation()  # Check MDX compilation with @mdx-js/mdx
         self.check_mdx_compatibility()
         self.check_cross_plugin_links()
+        self.check_document_indexes()
         self.check_formatting()
         self.check_readability()  # Check document readability
 

--- a/docuchango/validator.py
+++ b/docuchango/validator.py
@@ -828,13 +828,17 @@ class DocValidator:
                             )
 
                 if index_config.time_bucket:
-                    self._check_document_index_buckets(index_config.name, content, links, target_paths, index_config.time_bucket)
+                    self._check_document_index_buckets(
+                        index_config.name, content, links, target_paths, index_config.time_bucket
+                    )
 
                 self.log(f"   ✓ {index_config.name}: {len(target_paths)} target(s) checked")
             except Exception as e:
                 self.errors.append(f"Error checking document index '{index_config.name}': {e}")
 
-    def _check_document_index_buckets(self, name: str, content: str, links: dict[Path, tuple[int, str]], target_paths: set[Path], bucket_config) -> None:  # type: ignore[no-untyped-def]
+    def _check_document_index_buckets(
+        self, name: str, content: str, links: dict[Path, tuple[int, str]], target_paths: set[Path], bucket_config
+    ) -> None:  # type: ignore[no-untyped-def]
         """Validate that index links appear under the expected time or milestone bucket."""
         headings = self._extract_bucket_headings(content, bucket_config.heading_level)
         if not headings:

--- a/tests/test_document_indexes.py
+++ b/tests/test_document_indexes.py
@@ -1,0 +1,169 @@
+"""Tests for configured document index validation."""
+
+import tempfile
+from pathlib import Path
+
+import yaml
+
+from docuchango.validator import DocValidator
+
+
+def write_config(repo_root: Path, config_data: dict) -> None:
+    with (repo_root / "docs-project.yaml").open("w") as f:
+        yaml.dump(config_data, f)
+
+
+def test_document_index_requires_all_targets():
+    """Configured indexes must link every matching target by default."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        repo_root = Path(tmpdir)
+        docs = repo_root / "docs"
+        decisions = docs / "decisions"
+        decisions.mkdir(parents=True)
+
+        (decisions / "decision-a.md").write_text("# Decision A\n")
+        (decisions / "decision-b.md").write_text("# Decision B\n")
+        (docs / "design-index.md").write_text(
+            """# Design Index
+
+- [Decision A](./decisions/decision-a.md)
+"""
+        )
+
+        write_config(
+            repo_root,
+            {
+                "project": {"id": "index-project", "name": "Index Project"},
+                "indexes": [
+                    {
+                        "name": "Shared Design Index",
+                        "path": "docs/design-index.md",
+                        "targets": ["docs/decisions/*.md"],
+                    }
+                ],
+            },
+        )
+
+        validator = DocValidator(repo_root, verbose=False)
+        validator.check_document_indexes()
+
+        assert "Document index 'Shared Design Index' is missing target: docs/decisions/decision-b.md" in validator.errors
+
+
+def test_weekly_document_index_requires_bucket_headings_and_placement():
+    """Weekly indexes require each target link under its ISO week bucket."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        repo_root = Path(tmpdir)
+        docs = repo_root / "docs"
+        notes = docs / "release-notes"
+        notes.mkdir(parents=True)
+
+        (notes / "release-2026-05-18.md").write_text(
+            """---
+title: Release 2026-05-18
+created: 2026-05-18
+project_id: index-project
+doc_uuid: 11111111-1111-4111-8111-111111111111
+---
+
+# Release
+"""
+        )
+        (notes / "release-2026-05-25.md").write_text(
+            """---
+title: Release 2026-05-25
+created: 2026-05-25
+project_id: index-project
+doc_uuid: 22222222-2222-4222-8222-222222222222
+---
+
+# Release
+"""
+        )
+        (docs / "release-index.md").write_text(
+            """# Release Index
+
+## 2026-W21
+
+- [Release 2026-05-18](./release-notes/release-2026-05-18.md)
+- [Release 2026-05-25](./release-notes/release-2026-05-25.md)
+
+## 2026-W22
+"""
+        )
+
+        write_config(
+            repo_root,
+            {
+                "project": {"id": "index-project", "name": "Index Project"},
+                "indexes": [
+                    {
+                        "name": "Weekly Release Notes",
+                        "path": "docs/release-index.md",
+                        "targets": ["docs/release-notes/*.md"],
+                        "time_bucket": {
+                            "cadence": "weekly",
+                            "field": "created",
+                            "heading_pattern": r"^\d{4}-W\d{2}$",
+                        },
+                    }
+                ],
+            },
+        )
+
+        validator = DocValidator(repo_root, verbose=False)
+        validator.check_document_indexes()
+
+        assert (
+            "Document index 'Weekly Release Notes' links docs/release-notes/release-2026-05-25.md "
+            "under '2026-W21' instead of '2026-W22'"
+        ) in validator.errors
+
+
+def test_milestone_document_index_uses_configured_frontmatter_field():
+    """Milestone indexes can bucket targets by a configured frontmatter field."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        repo_root = Path(tmpdir)
+        docs = repo_root / "docs"
+        plans = docs / "plans"
+        plans.mkdir(parents=True)
+
+        (plans / "checkout-plan.md").write_text(
+            """---
+title: Checkout Plan
+milestone: M2
+project_id: index-project
+doc_uuid: 11111111-1111-4111-8111-111111111111
+---
+
+# Checkout Plan
+"""
+        )
+        (docs / "plan-index.md").write_text(
+            """# Plan Index
+
+## M1
+
+- [Checkout Plan](./plans/checkout-plan.md)
+"""
+        )
+
+        write_config(
+            repo_root,
+            {
+                "project": {"id": "index-project", "name": "Index Project"},
+                "indexes": [
+                    {
+                        "name": "Plan Index",
+                        "path": "docs/plan-index.md",
+                        "targets": ["docs/plans/*.md"],
+                        "time_bucket": {"cadence": "milestone", "milestone_field": "milestone"},
+                    }
+                ],
+            },
+        )
+
+        validator = DocValidator(repo_root, verbose=False)
+        validator.check_document_indexes()
+
+        assert "Document index 'Plan Index' missing bucket heading: M2" in validator.errors

--- a/tests/test_document_indexes.py
+++ b/tests/test_document_indexes.py
@@ -47,7 +47,9 @@ def test_document_index_requires_all_targets():
         validator = DocValidator(repo_root, verbose=False)
         validator.check_document_indexes()
 
-        assert "Document index 'Shared Design Index' is missing target: docs/decisions/decision-b.md" in validator.errors
+        assert (
+            "Document index 'Shared Design Index' is missing target: docs/decisions/decision-b.md" in validator.errors
+        )
 
 
 def test_weekly_document_index_requires_bucket_headings_and_placement():


### PR DESCRIPTION
## TLDR
Adds first-class `indexes` declarations to `docs-project.yaml` so Docuchango can validate Markdown files whose job is to index other repo documents. This covers simple indexes like shared design indexes, plus bucketed indexes like weekly release notes and milestone changelogs.

## Why
Some Markdown files are not standalone docs. They are navigation and coordination artifacts that must stay complete and well-organized as the repo changes.

Examples:
- A shared design index should include every design doc it claims to cover.
- A plan index should not silently miss upcoming work.
- Weekly release notes should put each note under the correct ISO week.
- Milestone changelogs should group entries under the right milestone.

Without explicit index rules, these files can drift even when every individual document validates correctly.

## Scope
This PR adds:
- Top-level `indexes:` support in `docs-project.yaml`.
- Validation that configured index files exist.
- Validation that index target globs are fully represented by Markdown links.
- Optional enforcement that indexes contain entries when targets exist.
- Optional rejection of Markdown file links outside the configured target set.
- Optional time bucket validation for `weekly`, `monthly`, `quarterly`, and `yearly` indexes.
- Optional milestone bucket validation using a configured frontmatter field.
- Template documentation showing design index, weekly release notes, and milestone changelog configs.
- Real temporary-doc-repo tests for the new index behavior.

This does not add automatic index generation or mutation. It only validates declared index discipline.

## Config Shape
```yaml
indexes:
  - name: Shared Design Index
    path: docs/design-index.md
    targets:
      - docs/design/**/*.md
    require_all_targets: true
    require_entries: true
    allow_extra_links: true

  - name: Weekly Release Notes
    path: docs/release-index.md
    targets:
      - docs/release-notes/*.md
    time_bucket:
      cadence: weekly
      field: created
      heading_level: 2
      heading_pattern: "^\\d{4}-W\\d{2}$"

  - name: Milestone Changelog
    path: docs/milestone-changelog.md
    targets:
      - docs/plans/*.md
    time_bucket:
      cadence: milestone
      milestone_field: milestone
      heading_level: 2
```

## Validation Examples

### Shared Design Index
```yaml
indexes:
  - name: Shared Design Index
    path: docs/design-index.md
    targets:
      - docs/decisions/*.md
```

Applied validations:
- `docs/design-index.md` must exist.
- Every file matching `docs/decisions/*.md` must be linked.
- If `require_entries` is true and targets exist, the index must include Markdown file links.
- With `allow_extra_links: false`, linked Markdown files must be within the configured target set.

Example failure:
```text
Document index 'Shared Design Index' is missing target: docs/decisions/decision-b.md
```

### Weekly Release Notes
```yaml
indexes:
  - name: Weekly Release Notes
    path: docs/release-index.md
    targets:
      - docs/release-notes/*.md
    time_bucket:
      cadence: weekly
      field: created
      heading_pattern: "^\\\\d{4}-W\\\\d{2}$"
```

Applied validations:
- All matching release-note files must be linked.
- Bucket headings must exist at the configured heading level.
- Bucket headings must match `heading_pattern` when supplied.
- Each target document uses its `created` field to compute an ISO week bucket such as `2026-W22`.
- Each link must appear under the matching weekly bucket heading.

Example failure:
```text
Document index 'Weekly Release Notes' links docs/release-notes/release-2026-05-25.md under '2026-W21' instead of '2026-W22'
```

### Milestone Changelog
```yaml
indexes:
  - name: Plan Index
    path: docs/plan-index.md
    targets:
      - docs/plans/*.md
    time_bucket:
      cadence: milestone
      milestone_field: milestone
```

Applied validations:
- All matching plan files must be linked.
- Each target document uses its configured milestone field as the expected bucket.
- The matching milestone heading must exist.
- Each link must appear under the matching milestone heading.

Example failure:
```text
Document index 'Plan Index' missing bucket heading: M2
```

## Testing
- `uv run pytest`
