### PR TITLE
feat: support sub-project docs configs

### DIFF
--- a/.github/workflows/publish-schema.yml
+++ b/.github/workflows/publish-schema.yml
@@ -1,0 +1,51 @@
+name: Publish Schema
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - docuchango/templates/docs-project.schema.json
+      - .github/workflows/publish-schema.yml
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    name: Publish docs-project schema
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}schemas/docs-project.schema.json
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Validate schema JSON
+        run: python -m json.tool docuchango/templates/docs-project.schema.json > /dev/null
+
+      - name: Build Pages artifact
+        run: |
+          mkdir -p site/schemas
+          cp docuchango/templates/docs-project.schema.json site/schemas/docs-project.schema.json
+          touch site/.nojekyll
+
+      - name: Configure Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: site
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -149,6 +149,8 @@ subprojects:
 
 Generated projects include `docs-project.schema.json` next to
 `docs-project.yaml` for editor validation and prompt-based config authoring.
+The same schema is published at
+`https://jrepp.github.io/docuchango/schemas/docs-project.schema.json`.
 
 ### Bootstrap & Guides
 

--- a/README.md
+++ b/README.md
@@ -118,7 +118,8 @@ default, but you can opt specific folders into plain Markdown when frontmatter
 is not a project goal.
 
 ```yaml
-config_version: "1"
+# yaml-language-server: $schema=./docs-project.schema.json
+version: "1"
 docuchango_version: "1.15.0"
 
 structure:
@@ -141,10 +142,13 @@ Parent repositories can also reference configs owned by sub-projects or git
 submodules, avoiding one giant root config:
 
 ```yaml
-sub_projects:
-  - vendor/service-a/docs-project.yaml
-  - path: vendor/service-b/docs-project.yaml
+subprojects:
+  - vendor/service-a
+  - vendor/service-b/docs-project.yaml
 ```
+
+Generated projects include `docs-project.schema.json` next to
+`docs-project.yaml` for editor validation and prompt-based config authoring.
 
 ### Bootstrap & Guides
 

--- a/README.md
+++ b/README.md
@@ -118,6 +118,9 @@ default, but you can opt specific folders into plain Markdown when frontmatter
 is not a project goal.
 
 ```yaml
+config_version: "1"
+docuchango_version: "1.15.0"
+
 structure:
   docs_roots: [docs]
   doc_types:
@@ -132,6 +135,15 @@ structure:
       filename_pattern: ".+\\.md$"
       enforce_filename_pattern: false
       require_frontmatter: false
+```
+
+Parent repositories can also reference configs owned by sub-projects or git
+submodules, avoiding one giant root config:
+
+```yaml
+sub_projects:
+  - vendor/service-a/docs-project.yaml
+  - path: vendor/service-b/docs-project.yaml
 ```
 
 ### Bootstrap & Guides

--- a/docs/AGENT_GUIDE.md
+++ b/docs/AGENT_GUIDE.md
@@ -51,6 +51,9 @@ ls docs-cms/rfcs/
 find docs-cms -name "*.md" -type f | head -20
 ```
 
+If the local schema is missing, use the stable published schema:
+`https://jrepp.github.io/docuchango/schemas/docs-project.schema.json`.
+
 **What to look for:**
 - Recent ADRs: What architectural decisions were made?
 - Active RFCs: What changes are being proposed?

--- a/docs/AGENT_GUIDE.md
+++ b/docs/AGENT_GUIDE.md
@@ -38,6 +38,9 @@ When you start working on a project, **immediately** read the docs-cms:
 # Find and read the project config
 cat docs-cms/docs-project.yaml
 
+# Read the config format and validation schema when editing project config
+cat docs-cms/docs-project.schema.json
+
 # List all ADRs (Architecture Decision Records)
 ls docs-cms/adr/
 
@@ -53,6 +56,7 @@ find docs-cms -name "*.md" -type f | head -20
 - Active RFCs: What changes are being proposed?
 - Project structure: How is the codebase organized?
 - Tech stack: What technologies are in use?
+- `subprojects`: Which nested docs projects or submodules should be loaded?
 
 ### 2. Answer User Questions
 

--- a/docs/BOOTSTRAP_GUIDE.md
+++ b/docs/BOOTSTRAP_GUIDE.md
@@ -226,6 +226,7 @@ docuchango validate --verbose
 my-project/
 ├── docs-cms/
 │   ├── docs-project.yaml       # Project configuration
+│   ├── docs-project.schema.json # Validation schema for project configuration
 │   ├── adr/                    # Architecture Decision Records
 │   │   ├── adr-001-*.md
 │   │   ├── adr-002-*.md
@@ -241,6 +242,16 @@ my-project/
 │       ├── rfc-template.md
 │       └── memo-template.md
 └── README.md
+```
+
+`docs-project.yaml` includes a YAML language-server pointer to
+`docs-project.schema.json`. Use that schema when editing config by hand or from
+an agent prompt. Parent repositories can include nested docs projects with:
+
+```yaml
+subprojects:
+  - vendor/service-a
+  - vendor/service-b/docs-project.yaml
 ```
 
 ## Document Types

--- a/docs/BOOTSTRAP_GUIDE.md
+++ b/docs/BOOTSTRAP_GUIDE.md
@@ -246,7 +246,9 @@ my-project/
 
 `docs-project.yaml` includes a YAML language-server pointer to
 `docs-project.schema.json`. Use that schema when editing config by hand or from
-an agent prompt. Parent repositories can include nested docs projects with:
+an agent prompt. The stable published schema URL is
+`https://jrepp.github.io/docuchango/schemas/docs-project.schema.json`.
+Parent repositories can include nested docs projects with:
 
 ```yaml
 subprojects:

--- a/docuchango/cli.py
+++ b/docuchango/cli.py
@@ -40,7 +40,7 @@ def _load_docs_project_config_from_candidates(candidates: list[Path]) -> tuple[D
 
 
 def _iter_docs_project_configs(root: Path) -> list[tuple[DocsProjectConfig, Path]]:
-    """Load the root docs-project.yaml plus any configured sub-projects."""
+    """Load the root docs-project.yaml plus any configured subprojects."""
     config, config_path = _load_docs_project_config(root)
     if not config or not config_path:
         return []
@@ -52,8 +52,10 @@ def _iter_docs_project_configs(root: Path) -> list[tuple[DocsProjectConfig, Path
     while pending:
         parent_config, parent_path = pending.pop(0)
         parent_base = parent_path.parent
-        for sub_project in parent_config.sub_projects:
-            sub_path = (parent_base / sub_project.path).resolve()
+        for subproject in parent_config.subprojects:
+            sub_path = (parent_base / subproject.path).resolve()
+            if sub_path.is_dir():
+                sub_path = sub_path / "docs-project.yaml"
             if sub_path in seen:
                 continue
             seen.add(sub_path)
@@ -412,6 +414,7 @@ def init(path: Path | None, project_id: str, project_name: str, force: bool):
 
     template_files = {
         "docs-project.yaml": path / "docs-project.yaml",
+        "docs-project.schema.json": path / "docs-project.schema.json",
         "README.md": path / "README.md",
         "adr-000-template.md": path / "templates" / "adr-000-template.md",
         "rfc-000-template.md": path / "templates" / "rfc-000-template.md",
@@ -464,8 +467,9 @@ def init(path: Path | None, project_id: str, project_name: str, force: bool):
     console.print(f"\n[bold green]✅ Successfully initialized docs-cms at {path}[/bold green]")
     console.print("\n[bold]Next steps:[/bold]")
     console.print("1. Review and customize docs-project.yaml")
-    console.print("2. Copy a template from templates/ to create your first document")
-    console.print("3. Run 'docuchango validate' to check your documents")
+    console.print("2. Use docs-project.schema.json as the config format reference")
+    console.print("3. Copy a template from templates/ to create your first document")
+    console.print("4. Run 'docuchango validate' to check your documents")
     console.print("\n[dim]Tip: Run 'docuchango bootstrap' for detailed setup instructions[/dim]")
 
 

--- a/docuchango/cli.py
+++ b/docuchango/cli.py
@@ -22,6 +22,11 @@ console = Console()
 def _load_docs_project_config(root: Path) -> tuple[DocsProjectConfig | None, Path | None]:
     """Load docs-project.yaml from repo root or docs-cms."""
     candidates = [root / "docs-project.yaml", root / "docs-cms" / "docs-project.yaml"]
+    return _load_docs_project_config_from_candidates(candidates)
+
+
+def _load_docs_project_config_from_candidates(candidates: list[Path]) -> tuple[DocsProjectConfig | None, Path | None]:
+    """Load the first valid docs-project.yaml from candidate paths."""
     for candidate in candidates:
         if not candidate.exists():
             continue
@@ -34,44 +39,73 @@ def _load_docs_project_config(root: Path) -> tuple[DocsProjectConfig | None, Pat
     return None, None
 
 
+def _iter_docs_project_configs(root: Path) -> list[tuple[DocsProjectConfig, Path]]:
+    """Load the root docs-project.yaml plus any configured sub-projects."""
+    config, config_path = _load_docs_project_config(root)
+    if not config or not config_path:
+        return []
+
+    configs = [(config, config_path)]
+    seen = {config_path.resolve()}
+    pending = [(config, config_path)]
+
+    while pending:
+        parent_config, parent_path = pending.pop(0)
+        parent_base = parent_path.parent
+        for sub_project in parent_config.sub_projects:
+            sub_path = (parent_base / sub_project.path).resolve()
+            if sub_path in seen:
+                continue
+            seen.add(sub_path)
+
+            sub_config, loaded_path = _load_docs_project_config_from_candidates([sub_path])
+            if not sub_config or not loaded_path:
+                continue
+
+            configs.append((sub_config, loaded_path))
+            pending.append((sub_config, loaded_path))
+
+    return configs
+
+
 def _discover_doc_files(root: Path) -> list[Path]:
     """Discover markdown docs, preferring docs-project.yaml when present."""
-    config, config_path = _load_docs_project_config(root)
+    configs = _iter_docs_project_configs(root)
 
-    # New mixed-schema mode
-    if config and config.structure and config.structure.doc_types and config_path:
-        config_base = config_path.parent
-        roots = config.structure.docs_roots or ["."]
-        files: list[Path] = []
-        seen: set[Path] = set()
+    if configs:
+        all_files: list[Path] = []
+        all_seen: set[Path] = set()
 
-        for doc_type_cfg in config.structure.doc_types.values():
-            for root_rel in roots:
-                root_path = (config_base / root_rel).resolve()
-                for folder in doc_type_cfg.folders:
-                    folder_path = (root_path / folder).resolve()
+        for config, config_path in configs:
+            if not config.structure:
+                continue
+            config_base = config_path.parent
+
+            if config.structure.doc_types:
+                roots = config.structure.docs_roots or ["."]
+                for doc_type_cfg in config.structure.doc_types.values():
+                    for root_rel in roots:
+                        root_path = (config_base / root_rel).resolve()
+                        for folder in doc_type_cfg.folders:
+                            folder_path = (root_path / folder).resolve()
+                            if not folder_path.exists():
+                                continue
+                            for file_path in folder_path.rglob("*.md"):
+                                if file_path not in all_seen:
+                                    all_seen.add(file_path)
+                                    all_files.append(file_path)
+            else:
+                for folder in config.structure.document_folders:
+                    folder_path = (config_base / folder).resolve()
                     if not folder_path.exists():
                         continue
                     for file_path in folder_path.rglob("*.md"):
-                        if file_path not in seen:
-                            seen.add(file_path)
-                            files.append(file_path)
-        return sorted(files)
+                        if file_path not in all_seen:
+                            all_seen.add(file_path)
+                            all_files.append(file_path)
 
-    if config and config.structure and config_path:
-        config_base = config_path.parent
-        files = []
-        seen = set()
-        for folder in config.structure.document_folders:
-            folder_path = (config_base / folder).resolve()
-            if not folder_path.exists():
-                continue
-            for file_path in folder_path.rglob("*.md"):
-                if file_path not in seen:
-                    seen.add(file_path)
-                    files.append(file_path)
-        if files:
-            return sorted(files)
+        if all_files:
+            return sorted(all_files)
 
     # Legacy mode (backwards compatibility)
     doc_patterns = [
@@ -406,6 +440,7 @@ def init(path: Path | None, project_id: str, project_name: str, force: bool):
                     "my-project": "\x00PROJECT_ID\x00",
                     "My Project": "\x00PROJECT_NAME\x00",
                     "2025-01-01": "\x00DATE\x00",
+                    "1.15.0": "\x00DOCUCHANGO_VERSION\x00",
                 }
 
                 # First pass: replace placeholders with unique markers
@@ -416,6 +451,7 @@ def init(path: Path | None, project_id: str, project_name: str, force: bool):
                 content = content.replace(markers["my-project"], project_id)
                 content = content.replace(markers["My Project"], project_name)
                 content = content.replace(markers["2025-01-01"], datetime.date.today().isoformat())
+                content = content.replace(markers["1.15.0"], __version__)
 
             dest_path.write_text(content)
             console.print(f"[green]✓[/green] Created: {dest_path.relative_to(path)}")

--- a/docuchango/schemas.py
+++ b/docuchango/schemas.py
@@ -8,9 +8,15 @@ from __future__ import annotations
 
 import datetime
 import re
+from importlib.metadata import PackageNotFoundError, version
 from typing import Literal
 
-from pydantic import BaseModel, ConfigDict, Field, field_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+try:
+    CURRENT_DOCUCHANGO_VERSION = version("docuchango")
+except PackageNotFoundError:
+    CURRENT_DOCUCHANGO_VERSION = "0.0.0.dev0"
 
 
 class DocTypeConfig(BaseModel):
@@ -256,6 +262,23 @@ class DocsProjectIndex(BaseModel):
     )
 
 
+class DocsProjectSubProject(BaseModel):
+    """Reference to another docs-project.yaml file, often in a git submodule."""
+
+    path: str = Field(
+        ...,
+        min_length=1,
+        description="Path to a sub-project docs-project.yaml, relative to the parent docs-project.yaml",
+    )
+
+    @model_validator(mode="before")
+    @classmethod
+    def allow_string_reference(cls, data):  # type: ignore[no-untyped-def]
+        if isinstance(data, str):
+            return {"path": data}
+        return data
+
+
 class DocsProjectConfig(BaseModel):
     """Schema for docs-project.yaml configuration file.
 
@@ -263,6 +286,14 @@ class DocsProjectConfig(BaseModel):
     defining project metadata, directory structure, and validation rules.
     """
 
+    config_version: str = Field(
+        default="1",
+        description="docs-project.yaml schema version. Reserved for future config migrations.",
+    )
+    docuchango_version: str = Field(
+        default=CURRENT_DOCUCHANGO_VERSION,
+        description="Docuchango version that generated or last updated this config.",
+    )
     project: DocsProjectInfo = Field(
         ...,
         description="Project information including ID, name, and description",
@@ -282,6 +313,10 @@ class DocsProjectConfig(BaseModel):
     indexes: list[DocsProjectIndex] = Field(
         default_factory=list,
         description="Markdown index files with stricter content discipline",
+    )
+    sub_projects: list[DocsProjectSubProject] = Field(
+        default_factory=list,
+        description="Additional docs-project.yaml files to load, relative to this config file. Useful for git submodules.",
     )
 
 

--- a/docuchango/schemas.py
+++ b/docuchango/schemas.py
@@ -262,13 +262,17 @@ class DocsProjectIndex(BaseModel):
     )
 
 
-class DocsProjectSubProject(BaseModel):
+class DocsProjectSubproject(BaseModel):
     """Reference to another docs-project.yaml file, often in a git submodule."""
+
+    model_config = ConfigDict(extra="forbid")
 
     path: str = Field(
         ...,
         min_length=1,
-        description="Path to a sub-project docs-project.yaml, relative to the parent docs-project.yaml",
+        description=(
+            "Path to a subproject directory or docs-project.yaml file, relative to the parent docs-project.yaml"
+        ),
     )
 
     @model_validator(mode="before")
@@ -286,7 +290,9 @@ class DocsProjectConfig(BaseModel):
     defining project metadata, directory structure, and validation rules.
     """
 
-    config_version: str = Field(
+    model_config = ConfigDict(extra="forbid")
+
+    version: str = Field(
         default="1",
         description="docs-project.yaml schema version. Reserved for future config migrations.",
     )
@@ -314,9 +320,9 @@ class DocsProjectConfig(BaseModel):
         default_factory=list,
         description="Markdown index files with stricter content discipline",
     )
-    sub_projects: list[DocsProjectSubProject] = Field(
+    subprojects: list[DocsProjectSubproject] = Field(
         default_factory=list,
-        description="Additional docs-project.yaml files to load, relative to this config file. Useful for git submodules.",
+        description="Additional docs projects to load, relative to this config file. Useful for git submodules.",
     )
 
 

--- a/docuchango/templates/README.md
+++ b/docuchango/templates/README.md
@@ -7,6 +7,7 @@ This directory contains structured technical documentation using the docs-cms pa
 ```
 docs-cms/
 ├── docs-project.yaml      # Project configuration
+├── docs-project.schema.json # Editor/agent schema for docs-project.yaml
 ├── adr/                   # Architecture Decision Records
 │   └── adr-000-template.md
 ├── rfcs/                  # Request for Comments
@@ -69,6 +70,10 @@ Edit `docs-project.yaml` to customize:
 - Folder names
 - Which folders to scan
 - Maintainer information
+
+The generated `docs-project.yaml` includes a YAML language-server pointer to
+`docs-project.schema.json`, which documents and validates the config format.
+Use `subprojects` to include docs configs from submodules or nested projects.
 
 ## Best Practices
 

--- a/docuchango/templates/docs-project.schema.json
+++ b/docuchango/templates/docs-project.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://github.com/jrepp/docuchango/schemas/docs-project.schema.json",
+  "$id": "https://jrepp.github.io/docuchango/schemas/docs-project.schema.json",
   "title": "Docuchango Docs Project",
   "type": "object",
   "additionalProperties": false,

--- a/docuchango/templates/docs-project.schema.json
+++ b/docuchango/templates/docs-project.schema.json
@@ -1,0 +1,155 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/jrepp/docuchango/schemas/docs-project.schema.json",
+  "title": "Docuchango Docs Project",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["project"],
+  "properties": {
+    "version": {
+      "type": "string",
+      "default": "1",
+      "description": "docs-project.yaml schema version. Reserved for future config migrations."
+    },
+    "docuchango_version": {
+      "type": "string",
+      "description": "Docuchango version that generated or last updated this config."
+    },
+    "project": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "name"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1,
+          "pattern": "^[a-z0-9\\-]+$"
+        },
+        "name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "description": {
+          "type": ["string", "null"]
+        }
+      }
+    },
+    "structure": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "adr_dir": {"type": "string", "default": "adr"},
+        "rfc_dir": {"type": "string", "default": "rfcs"},
+        "memo_dir": {"type": "string", "default": "memos"},
+        "prd_dir": {"type": "string", "default": "prd"},
+        "template_dir": {"type": "string", "default": "templates"},
+        "document_folders": {
+          "type": "array",
+          "items": {"type": "string"},
+          "default": ["adr", "rfcs", "memos", "prd"]
+        },
+        "docs_roots": {
+          "type": "array",
+          "items": {"type": "string"},
+          "default": ["."]
+        },
+        "doc_types": {
+          "type": ["object", "null"],
+          "additionalProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "schema": {
+                "type": "string",
+                "enum": ["adr", "rfc", "memo", "prd", "generic"],
+                "default": "generic"
+              },
+              "folders": {
+                "type": "array",
+                "items": {"type": "string"},
+                "default": []
+              },
+              "filename_pattern": {"type": ["string", "null"]},
+              "enforce_filename_pattern": {"type": "boolean", "default": true},
+              "require_frontmatter": {"type": "boolean", "default": true}
+            }
+          }
+        }
+      }
+    },
+    "subprojects": {
+      "type": "array",
+      "items": {
+        "oneOf": [
+          {"type": "string"},
+          {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["path"],
+            "properties": {
+              "path": {"type": "string", "minLength": 1}
+            }
+          }
+        ]
+      },
+      "default": []
+    },
+    "indexes": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["name", "path"],
+        "properties": {
+          "name": {"type": "string", "minLength": 1},
+          "path": {"type": "string", "minLength": 1},
+          "targets": {"type": "array", "items": {"type": "string"}, "default": []},
+          "require_all_targets": {"type": "boolean", "default": true},
+          "require_entries": {"type": "boolean", "default": true},
+          "allow_extra_links": {"type": "boolean", "default": true},
+          "time_bucket": {
+            "type": ["object", "null"],
+            "additionalProperties": false,
+            "required": ["cadence"],
+            "properties": {
+              "cadence": {
+                "type": "string",
+                "enum": ["weekly", "monthly", "quarterly", "yearly", "milestone"]
+              },
+              "field": {"type": "string", "default": "created"},
+              "milestone_field": {"type": "string", "default": "milestone"},
+              "heading_level": {"type": "integer", "minimum": 1, "maximum": 6, "default": 2},
+              "heading_pattern": {"type": ["string", "null"]}
+            }
+          }
+        }
+      },
+      "default": []
+    },
+    "metadata": {
+      "type": ["object", "null"],
+      "additionalProperties": false,
+      "required": ["created"],
+      "properties": {
+        "created": {"type": "string", "format": "date"},
+        "maintainers": {"type": "array", "items": {"type": "string"}, "default": []},
+        "purpose": {"type": ["string", "null"]}
+      }
+    },
+    "readability": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": {"type": "boolean", "default": true},
+        "flesch_reading_ease_min": {"type": ["number", "null"], "default": 60.0},
+        "flesch_kincaid_grade_max": {"type": ["number", "null"], "default": 10.0},
+        "gunning_fog_max": {"type": ["number", "null"], "default": 12.0},
+        "smog_index_max": {"type": ["number", "null"], "default": 12.0},
+        "automated_readability_index_max": {"type": ["number", "null"], "default": 10.0},
+        "coleman_liau_index_max": {"type": ["number", "null"], "default": 10.0},
+        "dale_chall_max": {"type": ["number", "null"], "default": 9.0},
+        "min_paragraph_length": {"type": "integer", "default": 100}
+      }
+    }
+  }
+}

--- a/docuchango/templates/docs-project.yaml
+++ b/docuchango/templates/docs-project.yaml
@@ -1,4 +1,5 @@
-config_version: "1"
+# yaml-language-server: $schema=./docs-project.schema.json
+version: "1"
 docuchango_version: "1.15.0"
 
 project:
@@ -43,13 +44,13 @@ structure:
   #     folders: [design]
   #     filename_pattern: ".+\\.md$"
   #     enforce_filename_pattern: false
-    #     require_frontmatter: false  # Allow plain Markdown design notes
+  #     require_frontmatter: false  # Allow plain Markdown design notes
 
-# Optional docs-project.yaml files to include. Paths are relative to this file,
-# which lets a parent repository validate docs configs stored inside git submodules.
-# sub_projects:
-#   - vendor/service-a/docs-project.yaml
-#   - path: vendor/service-b/docs-project.yaml
+# Optional subproject docs configs. Paths are relative to this file and can point
+# to either a subproject directory or its docs-project.yaml file.
+# subprojects:
+#   - vendor/service-a
+#   - vendor/service-b/docs-project.yaml
 
 # Optional Markdown files that index other repository files.
 # These rules are stricter than normal docs validation: targets can be required,

--- a/docuchango/templates/docs-project.yaml
+++ b/docuchango/templates/docs-project.yaml
@@ -1,3 +1,6 @@
+config_version: "1"
+docuchango_version: "1.15.0"
+
 project:
   id: my-project
   name: My Project
@@ -40,7 +43,13 @@ structure:
   #     folders: [design]
   #     filename_pattern: ".+\\.md$"
   #     enforce_filename_pattern: false
-  #     require_frontmatter: false  # Allow plain Markdown design notes
+    #     require_frontmatter: false  # Allow plain Markdown design notes
+
+# Optional docs-project.yaml files to include. Paths are relative to this file,
+# which lets a parent repository validate docs configs stored inside git submodules.
+# sub_projects:
+#   - vendor/service-a/docs-project.yaml
+#   - path: vendor/service-b/docs-project.yaml
 
 # Optional Markdown files that index other repository files.
 # These rules are stricter than normal docs validation: targets can be required,

--- a/docuchango/validator.py
+++ b/docuchango/validator.py
@@ -184,7 +184,11 @@ class DocValidator:
     def _load_project_config_at(self, config_path: Path) -> Optional[DocsProjectConfig]:
         """Load one docs-project.yaml file from an explicit path."""
         if not config_path.exists():
-            self.log(f"⚠️  Warning: Sub-project config not found: {config_path}")
+            self.log(
+                f"⚠️  Warning: Sub-project config not found: {config_path}. "
+                "Add the file or remove it from sub_projects.",
+                force=True,
+            )
             return None
 
         try:
@@ -194,10 +198,18 @@ class DocValidator:
             self.log(f"✓ Loaded sub-project config: {config.project.id} ({config_path})")
             return config
         except ValidationError as e:
-            self.log(f"⚠️  Warning: Invalid sub-project config format at {config_path}: {e}")
+            self.log(
+                f"⚠️  Warning: Invalid sub-project config format at {config_path}: {e}. "
+                "Fix the config or remove it from sub_projects.",
+                force=True,
+            )
             return None
         except Exception as e:
-            self.log(f"⚠️  Warning: Could not load sub-project config at {config_path}: {e}")
+            self.log(
+                f"⚠️  Warning: Could not load sub-project config at {config_path}: {e}. "
+                "Fix the config or remove it from sub_projects.",
+                force=True,
+            )
             return None
 
     def _load_project_config_contexts(self) -> list[ProjectConfigContext]:

--- a/docuchango/validator.py
+++ b/docuchango/validator.py
@@ -124,6 +124,18 @@ class Link:
         return f"{status} {self.source_doc.name}:{self.line_number} -> {self.target}"
 
 
+@dataclass
+class ProjectConfigContext:
+    """Loaded docs-project.yaml with its path for relative path resolution."""
+
+    config: DocsProjectConfig
+    path: Path
+
+    @property
+    def base_dir(self) -> Path:
+        return self.path.parent
+
+
 class DocValidator:
     """Validates documentation"""
 
@@ -139,6 +151,7 @@ class DocValidator:
         # Load project configuration
         self.project_config_path: Optional[Path] = None
         self.project_config = self._load_project_config()
+        self.project_configs = self._load_project_config_contexts()
 
     def _load_project_config(self) -> Optional[DocsProjectConfig]:
         """Load docs-project.yaml configuration"""
@@ -167,6 +180,52 @@ class DocValidator:
 
         self.log("⚠️  Warning: Project config not found (looked for docs-project.yaml at repo root and docs-cms/)")
         return None
+
+    def _load_project_config_at(self, config_path: Path) -> Optional[DocsProjectConfig]:
+        """Load one docs-project.yaml file from an explicit path."""
+        if not config_path.exists():
+            self.log(f"⚠️  Warning: Sub-project config not found: {config_path}")
+            return None
+
+        try:
+            with open(config_path, encoding="utf-8") as f:
+                config_data = yaml.safe_load(f)
+            config = DocsProjectConfig(**config_data)
+            self.log(f"✓ Loaded sub-project config: {config.project.id} ({config_path})")
+            return config
+        except ValidationError as e:
+            self.log(f"⚠️  Warning: Invalid sub-project config format at {config_path}: {e}")
+            return None
+        except Exception as e:
+            self.log(f"⚠️  Warning: Could not load sub-project config at {config_path}: {e}")
+            return None
+
+    def _load_project_config_contexts(self) -> list[ProjectConfigContext]:
+        """Load the primary project config and any referenced sub-project configs."""
+        if not self.project_config or not self.project_config_path:
+            return []
+
+        contexts = [ProjectConfigContext(self.project_config, self.project_config_path)]
+        seen = {self.project_config_path.resolve()}
+        pending = list(contexts)
+
+        while pending:
+            parent = pending.pop(0)
+            for sub_project in parent.config.sub_projects:
+                sub_path = (parent.base_dir / sub_project.path).resolve()
+                if sub_path in seen:
+                    continue
+                seen.add(sub_path)
+
+                sub_config = self._load_project_config_at(sub_path)
+                if not sub_config:
+                    continue
+
+                context = ProjectConfigContext(sub_config, sub_path)
+                contexts.append(context)
+                pending.append(context)
+
+        return contexts
 
     def _get_config_base_dir(self) -> Path:
         """Base directory for resolving structure paths."""
@@ -216,31 +275,50 @@ class DocValidator:
             "prd": r"^(prd)-(\d{3})-(.+)\.md$",
         }
 
-        config_base = self._get_config_base_dir()
+        contexts = self.project_configs or []
 
-        if self.project_config and self.project_config.structure and self.project_config.structure.doc_types:
-            roots = self.project_config.structure.docs_roots or ["."]
+        if contexts:
             entries: list[tuple[str, str, str, bool, bool, Path]] = []
+            for context in contexts:
+                config = context.config
+                config_base = context.base_dir
 
-            for doc_type_name, cfg in self.project_config.structure.doc_types.items():
-                pattern = cfg.filename_pattern or default_patterns.get(doc_type_name, r"^(.+)\.md$")
-                folders = cfg.folders or []
-                for root_rel in roots:
-                    root_path = (config_base / root_rel).resolve()
-                    for folder in folders:
+                if config.structure and config.structure.doc_types:
+                    roots = config.structure.docs_roots or ["."]
+                    for doc_type_name, cfg in config.structure.doc_types.items():
+                        pattern = cfg.filename_pattern or default_patterns.get(doc_type_name, r"^(.+)\.md$")
+                        folders = cfg.folders or []
+                        for root_rel in roots:
+                            root_path = (config_base / root_rel).resolve()
+                            for folder in folders:
+                                entries.append(
+                                    (
+                                        cfg.frontmatter_schema,
+                                        folder,
+                                        pattern,
+                                        cfg.enforce_filename_pattern,
+                                        cfg.require_frontmatter,
+                                        root_path,
+                                    )
+                                )
+                    continue
+
+                folder_config = {
+                    "adr": config.structure.adr_dir,
+                    "rfc": config.structure.rfc_dir,
+                    "memo": config.structure.memo_dir,
+                    "prd": config.structure.prd_dir,
+                }
+                for key, schema_name in [("adr", "adr"), ("rfc", "rfc"), ("memo", "memo"), ("prd", "prd")]:
+                    folder_name = folder_config[key]
+                    if folder_name in config.structure.document_folders:
                         entries.append(
-                            (
-                                cfg.frontmatter_schema,
-                                folder,
-                                pattern,
-                                cfg.enforce_filename_pattern,
-                                cfg.require_frontmatter,
-                                root_path,
-                            )
+                            (schema_name, folder_name, default_patterns[schema_name], True, True, config_base)
                         )
             return entries
 
         # Legacy behavior
+        config_base = self._get_config_base_dir()
         folder_config = self._get_folder_config()
         document_folders = self._get_document_folders()
 
@@ -314,9 +392,13 @@ class DocValidator:
                 require_frontmatter,
             )
 
-        # Scan general docs markdown files at docs roots
+        # Scan general docs markdown files at each configured docs root.
         roots_to_scan = [self._get_config_base_dir()]
-        if self.project_config and self.project_config.structure:
+        if self.project_configs:
+            roots_to_scan = []
+            for context in self.project_configs:
+                roots_to_scan.extend((context.base_dir / p).resolve() for p in context.config.structure.docs_roots)
+        elif self.project_config and self.project_config.structure:
             roots_to_scan = [
                 (self._get_config_base_dir() / p).resolve() for p in self.project_config.structure.docs_roots
             ]
@@ -791,53 +873,65 @@ class DocValidator:
 
     def check_document_indexes(self):
         """Validate configured Markdown index files."""
-        if not self.project_config or not self.project_config.indexes:
+        contexts = self.project_configs or []
+        if not contexts and self.project_config and self.project_config_path:
+            contexts = [ProjectConfigContext(self.project_config, self.project_config_path)]
+
+        contexts = [context for context in contexts if context.config.indexes]
+        if not contexts:
             return
 
         self.log("\n🗂️  Checking document indexes...")
-        config_base = self._get_config_base_dir()
 
-        for index_config in self.project_config.indexes:
-            index_path = (config_base / index_config.path).resolve()
-            if not index_path.exists():
-                self.errors.append(f"Document index '{index_config.name}' not found: {index_config.path}")
-                continue
+        for context in contexts:
+            config_base = context.base_dir
+            for index_config in context.config.indexes:
+                index_path = (config_base / index_config.path).resolve()
+                if not index_path.exists():
+                    self.errors.append(f"Document index '{index_config.name}' not found: {index_config.path}")
+                    continue
 
-            try:
-                content = index_path.read_text(encoding="utf-8")
-                links = self._extract_markdown_file_links(content, index_path)
-                target_paths: set[Path] = set()
-                for target_pattern in index_config.targets:
-                    target_paths.update(path.resolve() for path in config_base.glob(target_pattern) if path.is_file())
-                target_paths.discard(index_path)
+                try:
+                    content = index_path.read_text(encoding="utf-8")
+                    links = self._extract_markdown_file_links(content, index_path)
+                    target_paths: set[Path] = set()
+                    for target_pattern in index_config.targets:
+                        target_paths.update(path.resolve() for path in config_base.glob(target_pattern) if path.is_file())
+                    target_paths.discard(index_path)
 
-                if index_config.require_entries and target_paths and not links:
-                    self.errors.append(f"Document index '{index_config.name}' has no Markdown links")
+                    if index_config.require_entries and target_paths and not links:
+                        self.errors.append(f"Document index '{index_config.name}' has no Markdown links")
 
-                if index_config.require_all_targets:
-                    for target_path in sorted(target_paths):
-                        if target_path not in links:
-                            rel_target = target_path.relative_to(config_base)
-                            self.errors.append(f"Document index '{index_config.name}' is missing target: {rel_target}")
+                    if index_config.require_all_targets:
+                        for target_path in sorted(target_paths):
+                            if target_path not in links:
+                                rel_target = target_path.relative_to(config_base)
+                                self.errors.append(f"Document index '{index_config.name}' is missing target: {rel_target}")
 
-                if not index_config.allow_extra_links:
-                    for linked_path, (line_num, raw_target) in sorted(links.items()):
-                        if linked_path.exists() and linked_path not in target_paths:
-                            self.errors.append(
-                                f"Document index '{index_config.name}' line {line_num} links outside targets: {raw_target}"
-                            )
+                    if not index_config.allow_extra_links:
+                        for linked_path, (line_num, raw_target) in sorted(links.items()):
+                            if linked_path.exists() and linked_path not in target_paths:
+                                self.errors.append(
+                                    f"Document index '{index_config.name}' line {line_num} links outside targets: {raw_target}"
+                                )
 
-                if index_config.time_bucket:
-                    self._check_document_index_buckets(
-                        index_config.name, content, links, target_paths, index_config.time_bucket
-                    )
+                    if index_config.time_bucket:
+                        self._check_document_index_buckets(
+                            index_config.name, content, links, target_paths, index_config.time_bucket, config_base
+                        )
 
-                self.log(f"   ✓ {index_config.name}: {len(target_paths)} target(s) checked")
-            except Exception as e:
-                self.errors.append(f"Error checking document index '{index_config.name}': {e}")
+                    self.log(f"   ✓ {index_config.name}: {len(target_paths)} target(s) checked")
+                except Exception as e:
+                    self.errors.append(f"Error checking document index '{index_config.name}': {e}")
 
     def _check_document_index_buckets(
-        self, name: str, content: str, links: dict[Path, tuple[int, str]], target_paths: set[Path], bucket_config
+        self,
+        name: str,
+        content: str,
+        links: dict[Path, tuple[int, str]],
+        target_paths: set[Path],
+        bucket_config,
+        config_base: Path,
     ) -> None:  # type: ignore[no-untyped-def]
         """Validate that index links appear under the expected time or milestone bucket."""
         headings = self._extract_bucket_headings(content, bucket_config.heading_level)
@@ -866,11 +960,11 @@ class DocValidator:
             try:
                 expected_bucket = self._bucket_for_target(target_path, bucket_config)
             except Exception as e:
-                rel_target = target_path.relative_to(self._get_config_base_dir())
+                rel_target = target_path.relative_to(config_base)
                 self.errors.append(f"Document index '{name}' cannot read bucket for {rel_target}: {e}")
                 continue
 
-            rel_target = target_path.relative_to(self._get_config_base_dir())
+            rel_target = target_path.relative_to(config_base)
             if not expected_bucket:
                 self.errors.append(f"Document index '{name}' cannot determine bucket for {rel_target}")
                 continue

--- a/docuchango/validator.py
+++ b/docuchango/validator.py
@@ -185,8 +185,7 @@ class DocValidator:
         """Load one docs-project.yaml file from an explicit path."""
         if not config_path.exists():
             self.log(
-                f"⚠️  Warning: Sub-project config not found: {config_path}. "
-                "Add the file or remove it from subprojects.",
+                f"⚠️  Warning: Sub-project config not found: {config_path}. Add the file or remove it from subprojects.",
                 force=True,
             )
             return None
@@ -855,7 +854,7 @@ class DocValidator:
 
         return headings
 
-    def _bucket_for_target(self, target_path: Path, bucket_config) -> Optional[str]:  # type: ignore[no-untyped-def]
+    def _bucket_for_target(self, target_path: Path, bucket_config) -> Optional[str]:
         """Compute the expected index bucket for a target document."""
         post = frontmatter.loads(target_path.read_text(encoding="utf-8"))
 
@@ -910,7 +909,9 @@ class DocValidator:
                     links = self._extract_markdown_file_links(content, index_path)
                     target_paths: set[Path] = set()
                     for target_pattern in index_config.targets:
-                        target_paths.update(path.resolve() for path in config_base.glob(target_pattern) if path.is_file())
+                        target_paths.update(
+                            path.resolve() for path in config_base.glob(target_pattern) if path.is_file()
+                        )
                     target_paths.discard(index_path)
 
                     if index_config.require_entries and target_paths and not links:
@@ -920,7 +921,9 @@ class DocValidator:
                         for target_path in sorted(target_paths):
                             if target_path not in links:
                                 rel_target = target_path.relative_to(config_base)
-                                self.errors.append(f"Document index '{index_config.name}' is missing target: {rel_target}")
+                                self.errors.append(
+                                    f"Document index '{index_config.name}' is missing target: {rel_target}"
+                                )
 
                     if not index_config.allow_extra_links:
                         for linked_path, (line_num, raw_target) in sorted(links.items()):
@@ -946,7 +949,7 @@ class DocValidator:
         target_paths: set[Path],
         bucket_config,
         config_base: Path,
-    ) -> None:  # type: ignore[no-untyped-def]
+    ) -> None:
         """Validate that index links appear under the expected time or milestone bucket."""
         headings = self._extract_bucket_headings(content, bucket_config.heading_level)
         if not headings:

--- a/docuchango/validator.py
+++ b/docuchango/validator.py
@@ -186,7 +186,7 @@ class DocValidator:
         if not config_path.exists():
             self.log(
                 f"⚠️  Warning: Sub-project config not found: {config_path}. "
-                "Add the file or remove it from sub_projects.",
+                "Add the file or remove it from subprojects.",
                 force=True,
             )
             return None
@@ -200,14 +200,14 @@ class DocValidator:
         except ValidationError as e:
             self.log(
                 f"⚠️  Warning: Invalid sub-project config format at {config_path}: {e}. "
-                "Fix the config or remove it from sub_projects.",
+                "Fix the config or remove it from subprojects.",
                 force=True,
             )
             return None
         except Exception as e:
             self.log(
                 f"⚠️  Warning: Could not load sub-project config at {config_path}: {e}. "
-                "Fix the config or remove it from sub_projects.",
+                "Fix the config or remove it from subprojects.",
                 force=True,
             )
             return None
@@ -223,8 +223,10 @@ class DocValidator:
 
         while pending:
             parent = pending.pop(0)
-            for sub_project in parent.config.sub_projects:
-                sub_path = (parent.base_dir / sub_project.path).resolve()
+            for subproject in parent.config.subprojects:
+                sub_path = (parent.base_dir / subproject.path).resolve()
+                if sub_path.is_dir():
+                    sub_path = sub_path / "docs-project.yaml"
                 if sub_path in seen:
                     continue
                 seen.add(sub_path)

--- a/tests/test_config_loading.py
+++ b/tests/test_config_loading.py
@@ -736,3 +736,94 @@ doc_uuid: 33333333-3333-4333-8333-333333333333
             doc_path.write_text("# Not parsed by discovery\n")
 
             assert _discover_doc_files(repo_root) == [doc_path.resolve()]
+
+    def test_missing_sub_project_config_warns_and_continues(self, capsys):
+        """Missing sub-project configs should warn with remediation and keep validating parent docs."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo_root = Path(tmpdir)
+            adr_dir = repo_root / "adr"
+            adr_dir.mkdir()
+
+            (repo_root / "docs-project.yaml").write_text(
+                yaml.dump(
+                    {
+                        "project": {"id": "parent-project", "name": "Parent Project"},
+                        "structure": {"document_folders": ["adr"]},
+                        "sub_projects": ["missing-submodule/docs-project.yaml"],
+                    }
+                )
+            )
+            (adr_dir / "adr-001-parent-decision.md").write_text(
+                """---
+title: Parent Decision
+status: Accepted
+created: 2025-01-01
+deciders: Core Team
+tags: [architecture]
+id: adr-001
+project_id: parent-project
+doc_uuid: 11111111-1111-4111-8111-111111111111
+---
+
+# Parent ADR content
+"""
+            )
+
+            validator = DocValidator(repo_root, verbose=False)
+            validator.scan_documents()
+
+            output = capsys.readouterr().out
+            assert "Sub-project config not found" in output
+            assert "Add the file or remove it from sub_projects" in output
+            assert [context.config.project.id for context in validator.project_configs] == ["parent-project"]
+            assert [doc.file_path.name for doc in validator.documents] == ["adr-001-parent-decision.md"]
+
+    def test_invalid_sub_project_config_warns_and_continues(self, capsys):
+        """Invalid sub-project configs should warn with remediation and keep validating parent docs."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo_root = Path(tmpdir)
+            submodule = repo_root / "vendor" / "invalid-service"
+            adr_dir = repo_root / "adr"
+            submodule.mkdir(parents=True)
+            adr_dir.mkdir()
+
+            (repo_root / "docs-project.yaml").write_text(
+                yaml.dump(
+                    {
+                        "project": {"id": "parent-project", "name": "Parent Project"},
+                        "structure": {"document_folders": ["adr"]},
+                        "sub_projects": ["vendor/invalid-service/docs-project.yaml"],
+                    }
+                )
+            )
+            (submodule / "docs-project.yaml").write_text(
+                yaml.dump(
+                    {
+                        "project": {"id": "Invalid_ID", "name": "Invalid Service"},
+                    }
+                )
+            )
+            (adr_dir / "adr-001-parent-decision.md").write_text(
+                """---
+title: Parent Decision
+status: Accepted
+created: 2025-01-01
+deciders: Core Team
+tags: [architecture]
+id: adr-001
+project_id: parent-project
+doc_uuid: 11111111-1111-4111-8111-111111111111
+---
+
+# Parent ADR content
+"""
+            )
+
+            validator = DocValidator(repo_root, verbose=False)
+            validator.scan_documents()
+
+            output = capsys.readouterr().out
+            assert "Invalid sub-project config format" in output
+            assert "Fix the config or remove it from sub_projects" in output
+            assert [context.config.project.id for context in validator.project_configs] == ["parent-project"]
+            assert [doc.file_path.name for doc in validator.documents] == ["adr-001-parent-decision.md"]

--- a/tests/test_config_loading.py
+++ b/tests/test_config_loading.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 import yaml
 
+from docuchango.cli import _discover_doc_files
 from docuchango.validator import DocValidator
 
 
@@ -78,6 +79,8 @@ class TestConfigLoading:
 
             # Check config was loaded with defaults
             assert validator.project_config is not None
+            assert validator.project_config.config_version == "1"
+            assert validator.project_config.docuchango_version
             assert validator.project_config.structure.adr_dir == "adr"
             assert validator.project_config.structure.prd_dir == "prd"
             assert validator.project_config.structure.document_folders == ["adr", "rfcs", "memos", "prd"]
@@ -577,3 +580,159 @@ This document omits frontmatter and should still fail by default.
 
             assert len(validator.documents) == 1
             assert validator.documents[0].errors == ["Missing YAML frontmatter"]
+
+    def test_sub_projects_load_multi_project_config_with_legacy_files(self):
+        """Parent configs can reference multiple sub-project configs and keep legacy docs."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo_root = Path(tmpdir)
+            legacy_adr_dir = repo_root / "adr"
+            service_a = repo_root / "vendor" / "service-a"
+            service_a_docs = service_a / "docs" / "adr"
+            service_b = repo_root / "vendor" / "service-b"
+            service_b_memos = service_b / "memos"
+            legacy_adr_dir.mkdir(parents=True)
+            service_a_docs.mkdir(parents=True)
+            service_b_memos.mkdir(parents=True)
+
+            (repo_root / "docs-project.yaml").write_text(
+                yaml.dump(
+                    {
+                        "config_version": "1",
+                        "docuchango_version": "1.15.0",
+                        "project": {"id": "parent-project", "name": "Parent Project"},
+                        "structure": {"document_folders": ["adr"]},
+                        "sub_projects": [
+                            "vendor/service-a/docs-project.yaml",
+                            {"path": "vendor/service-b/docs-project.yaml"},
+                        ],
+                    }
+                )
+            )
+            (service_a / "docs-project.yaml").write_text(
+                yaml.dump(
+                    {
+                        "config_version": "1",
+                        "docuchango_version": "1.15.0",
+                        "project": {"id": "service-a", "name": "Service A"},
+                        "structure": {
+                            "docs_roots": ["docs"],
+                            "doc_types": {
+                                "adr": {
+                                    "schema": "adr",
+                                    "folders": ["adr"],
+                                    "filename_pattern": r"^(adr)-(\d{3})-(.+)\.md$",
+                                }
+                            },
+                        },
+                    }
+                )
+            )
+            (service_b / "docs-project.yaml").write_text(
+                yaml.dump(
+                    {
+                        "config_version": "1",
+                        "docuchango_version": "1.15.0",
+                        "project": {"id": "service-b", "name": "Service B"},
+                        "structure": {"document_folders": ["memos"]},
+                    }
+                )
+            )
+
+            (legacy_adr_dir / "adr-001-parent-legacy.md").write_text(
+                """---
+title: Parent Legacy Decision
+status: Accepted
+created: 2025-01-01
+deciders: Core Team
+tags: [architecture]
+id: adr-001
+project_id: parent-project
+doc_uuid: 11111111-1111-4111-8111-111111111111
+---
+
+# Legacy ADR content
+"""
+            )
+            (service_a_docs / "adr-002-submodule-decision.md").write_text(
+                """---
+title: Submodule Decision
+status: Accepted
+created: 2025-01-01
+deciders: Core Team
+tags: [architecture]
+id: adr-002
+project_id: service-a
+doc_uuid: 22222222-2222-4222-8222-222222222222
+---
+
+# ADR content
+"""
+            )
+            (service_b_memos / "memo-001-legacy-submodule.md").write_text(
+                """---
+title: Legacy Submodule Memo
+author: Platform Team
+created: 2025-01-01
+tags: [operations]
+id: memo-001
+project_id: service-b
+doc_uuid: 33333333-3333-4333-8333-333333333333
+---
+
+# Memo content
+"""
+            )
+
+            validator = DocValidator(repo_root, verbose=False)
+            validator.scan_documents()
+
+            assert len(validator.project_configs) == 3
+            assert [context.config.project.id for context in validator.project_configs] == [
+                "parent-project",
+                "service-a",
+                "service-b",
+            ]
+            assert [context.config.config_version for context in validator.project_configs] == ["1", "1", "1"]
+            assert [context.config.docuchango_version for context in validator.project_configs] == [
+                "1.15.0",
+                "1.15.0",
+                "1.15.0",
+            ]
+            assert sorted(doc.file_path.name for doc in validator.documents) == [
+                "adr-001-parent-legacy.md",
+                "adr-002-submodule-decision.md",
+                "memo-001-legacy-submodule.md",
+            ]
+
+    def test_discover_doc_files_includes_sub_project_configs(self):
+        """CLI file discovery includes docs found through sub-project references."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo_root = Path(tmpdir)
+            submodule = repo_root / "libs" / "service-b"
+            docs_dir = submodule / "adr"
+            docs_dir.mkdir(parents=True)
+
+            (repo_root / "docs-project.yaml").write_text(
+                yaml.dump(
+                    {
+                        "config_version": "1",
+                        "docuchango_version": "1.15.0",
+                        "project": {"id": "parent-project", "name": "Parent Project"},
+                        "sub_projects": [{"path": "libs/service-b/docs-project.yaml"}],
+                    }
+                )
+            )
+            (submodule / "docs-project.yaml").write_text(
+                yaml.dump(
+                    {
+                        "config_version": "1",
+                        "docuchango_version": "1.15.0",
+                        "project": {"id": "service-b", "name": "Service B"},
+                        "structure": {"document_folders": ["adr"]},
+                    }
+                )
+            )
+            doc_path = docs_dir / "adr-001-service-b.md"
+            doc_path.write_text("# Not parsed by discovery\n")
+
+            assert _discover_doc_files(repo_root) == [doc_path.resolve()]

--- a/tests/test_config_loading.py
+++ b/tests/test_config_loading.py
@@ -1,5 +1,6 @@
 """Test suite for docs-project.yaml configuration loading."""
 
+import json
 import tempfile
 from pathlib import Path
 
@@ -11,6 +12,16 @@ from docuchango.validator import DocValidator
 
 class TestConfigLoading:
     """Test configuration file loading in DocValidator."""
+
+    def test_docs_project_json_schema_exists_for_editor_validation(self):
+        """Generated docs projects should have a JSON Schema for docs-project.yaml."""
+        schema_path = Path(__file__).parent.parent / "docuchango" / "templates" / "docs-project.schema.json"
+        schema = json.loads(schema_path.read_text())
+
+        assert schema["$schema"] == "https://json-schema.org/draft/2020-12/schema"
+        assert schema["properties"]["version"]["default"] == "1"
+        assert "subprojects" in schema["properties"]
+        assert schema["properties"]["subprojects"]["items"]["oneOf"][0]["type"] == "string"
 
     def test_load_valid_config(self):
         """Test that valid config file is loaded correctly."""
@@ -79,7 +90,7 @@ class TestConfigLoading:
 
             # Check config was loaded with defaults
             assert validator.project_config is not None
-            assert validator.project_config.config_version == "1"
+            assert validator.project_config.version == "1"
             assert validator.project_config.docuchango_version
             assert validator.project_config.structure.adr_dir == "adr"
             assert validator.project_config.structure.prd_dir == "prd"
@@ -581,8 +592,8 @@ This document omits frontmatter and should still fail by default.
             assert len(validator.documents) == 1
             assert validator.documents[0].errors == ["Missing YAML frontmatter"]
 
-    def test_sub_projects_load_multi_project_config_with_legacy_files(self):
-        """Parent configs can reference multiple sub-project configs and keep legacy docs."""
+    def test_subprojects_load_multi_project_config_with_legacy_files(self):
+        """Parent configs can reference multiple subproject configs and keep legacy docs."""
         with tempfile.TemporaryDirectory() as tmpdir:
             repo_root = Path(tmpdir)
             legacy_adr_dir = repo_root / "adr"
@@ -597,12 +608,12 @@ This document omits frontmatter and should still fail by default.
             (repo_root / "docs-project.yaml").write_text(
                 yaml.dump(
                     {
-                        "config_version": "1",
+                        "version": "1",
                         "docuchango_version": "1.15.0",
                         "project": {"id": "parent-project", "name": "Parent Project"},
                         "structure": {"document_folders": ["adr"]},
-                        "sub_projects": [
-                            "vendor/service-a/docs-project.yaml",
+                        "subprojects": [
+                            "vendor/service-a",
                             {"path": "vendor/service-b/docs-project.yaml"},
                         ],
                     }
@@ -611,7 +622,7 @@ This document omits frontmatter and should still fail by default.
             (service_a / "docs-project.yaml").write_text(
                 yaml.dump(
                     {
-                        "config_version": "1",
+                        "version": "1",
                         "docuchango_version": "1.15.0",
                         "project": {"id": "service-a", "name": "Service A"},
                         "structure": {
@@ -630,7 +641,7 @@ This document omits frontmatter and should still fail by default.
             (service_b / "docs-project.yaml").write_text(
                 yaml.dump(
                     {
-                        "config_version": "1",
+                        "version": "1",
                         "docuchango_version": "1.15.0",
                         "project": {"id": "service-b", "name": "Service B"},
                         "structure": {"document_folders": ["memos"]},
@@ -692,7 +703,7 @@ doc_uuid: 33333333-3333-4333-8333-333333333333
                 "service-a",
                 "service-b",
             ]
-            assert [context.config.config_version for context in validator.project_configs] == ["1", "1", "1"]
+            assert [context.config.version for context in validator.project_configs] == ["1", "1", "1"]
             assert [context.config.docuchango_version for context in validator.project_configs] == [
                 "1.15.0",
                 "1.15.0",
@@ -715,17 +726,17 @@ doc_uuid: 33333333-3333-4333-8333-333333333333
             (repo_root / "docs-project.yaml").write_text(
                 yaml.dump(
                     {
-                        "config_version": "1",
+                        "version": "1",
                         "docuchango_version": "1.15.0",
                         "project": {"id": "parent-project", "name": "Parent Project"},
-                        "sub_projects": [{"path": "libs/service-b/docs-project.yaml"}],
+                        "subprojects": [{"path": "libs/service-b"}],
                     }
                 )
             )
             (submodule / "docs-project.yaml").write_text(
                 yaml.dump(
                     {
-                        "config_version": "1",
+                        "version": "1",
                         "docuchango_version": "1.15.0",
                         "project": {"id": "service-b", "name": "Service B"},
                         "structure": {"document_folders": ["adr"]},
@@ -749,7 +760,7 @@ doc_uuid: 33333333-3333-4333-8333-333333333333
                     {
                         "project": {"id": "parent-project", "name": "Parent Project"},
                         "structure": {"document_folders": ["adr"]},
-                        "sub_projects": ["missing-submodule/docs-project.yaml"],
+                        "subprojects": ["missing-submodule"],
                     }
                 )
             )
@@ -774,7 +785,7 @@ doc_uuid: 11111111-1111-4111-8111-111111111111
 
             output = capsys.readouterr().out
             assert "Sub-project config not found" in output
-            assert "Add the file or remove it from sub_projects" in output
+            assert "Add the file or remove it from subprojects" in output
             assert [context.config.project.id for context in validator.project_configs] == ["parent-project"]
             assert [doc.file_path.name for doc in validator.documents] == ["adr-001-parent-decision.md"]
 
@@ -792,7 +803,7 @@ doc_uuid: 11111111-1111-4111-8111-111111111111
                     {
                         "project": {"id": "parent-project", "name": "Parent Project"},
                         "structure": {"document_folders": ["adr"]},
-                        "sub_projects": ["vendor/invalid-service/docs-project.yaml"],
+                        "subprojects": ["vendor/invalid-service"],
                     }
                 )
             )
@@ -824,6 +835,6 @@ doc_uuid: 11111111-1111-4111-8111-111111111111
 
             output = capsys.readouterr().out
             assert "Invalid sub-project config format" in output
-            assert "Fix the config or remove it from sub_projects" in output
+            assert "Fix the config or remove it from subprojects" in output
             assert [context.config.project.id for context in validator.project_configs] == ["parent-project"]
             assert [doc.file_path.name for doc in validator.documents] == ["adr-001-parent-decision.md"]

--- a/tests/test_document_indexes.py
+++ b/tests/test_document_indexes.py
@@ -8,7 +8,7 @@ import yaml
 from docuchango.validator import DocValidator
 
 
-def write_config(repo_root: Path, config_data: dict) -> None:
+def write_config(repo_root: Path, config_data: dict[str, object]) -> None:
     with (repo_root / "docs-project.yaml").open("w") as f:
         yaml.dump(config_data, f)
 

--- a/tests/test_init_command.py
+++ b/tests/test_init_command.py
@@ -46,6 +46,7 @@ class TestInitCommand:
 
             # Check files
             assert (docs_cms / "docs-project.yaml").exists()
+            assert (docs_cms / "docs-project.schema.json").exists()
             assert (docs_cms / "README.md").exists()
             assert (docs_cms / "templates" / "adr-000-template.md").exists()
             assert (docs_cms / "templates" / "rfc-000-template.md").exists()
@@ -221,6 +222,9 @@ class TestInitCommand:
             content = config_path.read_text()
 
             # Check for main sections
+            assert "# yaml-language-server: $schema=./docs-project.schema.json" in content
+            assert 'version: "1"' in content
+            assert "docuchango_version:" in content
             assert "project:" in content
             assert "structure:" in content
             assert "metadata:" in content

--- a/uv.lock
+++ b/uv.lock
@@ -282,7 +282,7 @@ toml = [
 
 [[package]]
 name = "docuchango"
-version = "1.13.0"
+version = "1.15.0"
 source = { editable = "." }
 dependencies = [
     { name = "click", version = "8.1.8", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },


### PR DESCRIPTION
## Summary
- Add `sub_projects` support so parent docs projects can include `docs-project.yaml` files from submodules or nested projects.
- Add `config_version` and `docuchango_version` metadata for future docs-project versioning.
- Aggregate validator scanning, document index checks, and CLI discovery across parent and sub-project configs while preserving legacy folder behavior.
- Add graceful degradation for missing or invalid sub-project configs with remediation warnings.

## Tests
- `uv run ruff check docuchango tests/test_config_loading.py`
- `uv run pytest`
- Result: 584 passed, 1 skipped