### PR TITLE
fix: restore main CI checks

### DIFF
--- a/tests/test_naming.py
+++ b/tests/test_naming.py
@@ -381,4 +381,3 @@ class TestIntegration:
         """Test that non-.md files are rejected."""
         for _name, pattern in BUILTIN_NAMING_STANDARDS.items():
             assert validate_name("document.txt", pattern) is False
-

--- a/uv.lock
+++ b/uv.lock
@@ -282,7 +282,7 @@ toml = [
 
 [[package]]
 name = "docuchango"
-version = "1.16.0"
+version = "1.17.0"
 source = { editable = "." }
 dependencies = [
     { name = "click", version = "8.1.8", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },


### PR DESCRIPTION
## Summary
- Remove the Ruff formatting violation in tests/test_naming.py.
- Update uv.lock so the editable docuchango package version matches pyproject.toml at 1.17.0.
- Enabled GitHub Pages workflow builds for the repository so the existing Publish Schema workflow can configure and deploy Pages.

## Coverage
- uv sync --all-extras
- uv run ruff format --check .
- uv run ruff check . --output-format=github
- uv run mypy docuchango tests
- uv run pytest
- uv build
- uv tool run twine check dist/*