### PR TITLE
chore: remove legacy Python 3.9 cleanup and add 3.14

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ['3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
 
     steps:
     - uses: actions/checkout@v6.0.2
@@ -33,7 +33,7 @@ jobs:
 
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v6.0.1
-      if: matrix.python-version == '3.13'
+      if: matrix.python-version == '3.14'
       with:
         files: ./coverage.xml
         flags: unittests
@@ -51,7 +51,7 @@ jobs:
       uses: astral-sh/setup-uv@v8.1.0
 
     - name: Set up Python
-      run: uv python install 3.13
+      run: uv python install 3.14
 
     - name: Install dependencies
       run: uv sync --all-extras
@@ -84,7 +84,7 @@ jobs:
       uses: astral-sh/setup-uv@v8.1.0
 
     - name: Set up Python
-      run: uv python install 3.13
+      run: uv python install 3.14
 
     - name: Build package
       run: uv build

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -4,7 +4,7 @@ This guide covers how to publish the `docuchango` package to PyPI and TestPyPI.
 
 ## Prerequisites
 
-1. Python 3.9+ installed
+1. Python 3.10+ installed
 2. `uv` installed (recommended) or `pip` with `build` and `twine`
 3. PyPI and/or TestPyPI account
 4. API tokens for PyPI/TestPyPI

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![PyPI version](https://badge.fury.io/py/docuchango.svg)](https://pypi.org/project/docuchango/)
 [![CI](https://github.com/jrepp/docuchango/workflows/CI/badge.svg)](https://github.com/jrepp/docuchango/actions)
 [![codecov](https://codecov.io/gh/jrepp/docuchango/branch/main/graph/badge.svg)](https://codecov.io/gh/jrepp/docuchango)
-[![Python Version](https://img.shields.io/badge/python-3.9%20%7C%203.10%20%7C%203.11%20%7C%203.12%20%7C%203.13-blue)](https://www.python.org/downloads/)
+[![Python Version](https://img.shields.io/badge/python-3.10%20%7C%203.11%20%7C%203.12%20%7C%203.13-blue)](https://www.python.org/downloads/)
 [![License: MPL 2.0](https://img.shields.io/badge/License-MPL%202.0-brightgreen.svg)](https://opensource.org/licenses/MPL-2.0)
 
 [![Code style: ruff](https://img.shields.io/badge/code%20style-ruff-000000.svg)](https://github.com/astral-sh/ruff)
@@ -293,7 +293,7 @@ pytest -v                   # Verbose output
 # • 628 passing tests (with textstat installed)
 # • 569 core tests + 59 readability tests
 # • Zero flaky or xfail tests
-# • Full Python 3.9-3.13 compatibility
+# • Full Python 3.10-3.13 compatibility
 # • Comprehensive edge case coverage (frontmatter, links, timestamps, bulk updates)
 
 # Lint
@@ -314,7 +314,7 @@ uv build
 
 ## Requirements
 
-- Python 3.9+
+- Python 3.10+
 - Works on macOS, Linux, Windows
 
 ## License

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![PyPI version](https://badge.fury.io/py/docuchango.svg)](https://pypi.org/project/docuchango/)
 [![CI](https://github.com/jrepp/docuchango/workflows/CI/badge.svg)](https://github.com/jrepp/docuchango/actions)
 [![codecov](https://codecov.io/gh/jrepp/docuchango/branch/main/graph/badge.svg)](https://codecov.io/gh/jrepp/docuchango)
-[![Python Version](https://img.shields.io/badge/python-3.10%20%7C%203.11%20%7C%203.12%20%7C%203.13-blue)](https://www.python.org/downloads/)
+[![Python Version](https://img.shields.io/badge/python-3.10%20%7C%203.11%20%7C%203.12%20%7C%203.13%20%7C%203.14-blue)](https://www.python.org/downloads/)
 [![License: MPL 2.0](https://img.shields.io/badge/License-MPL%202.0-brightgreen.svg)](https://opensource.org/licenses/MPL-2.0)
 
 [![Code style: ruff](https://img.shields.io/badge/code%20style-ruff-000000.svg)](https://github.com/astral-sh/ruff)
@@ -293,7 +293,7 @@ pytest -v                   # Verbose output
 # • 628 passing tests (with textstat installed)
 # • 569 core tests + 59 readability tests
 # • Zero flaky or xfail tests
-# • Full Python 3.10-3.13 compatibility
+# • Full Python 3.10-3.14 compatibility
 # • Comprehensive edge case coverage (frontmatter, links, timestamps, bulk updates)
 
 # Lint

--- a/docs-cms/prd/prd-001-validation-framework.md
+++ b/docs-cms/prd/prd-001-validation-framework.md
@@ -154,7 +154,7 @@ docuchango fix all
 
 **Testing:**
 - 61 tests covering validation, fixing, and schemas
-- Runs in CI on Python 3.10-3.13
+- Runs in CI on Python 3.10-3.14
 
 ## Why Docuchango?
 

--- a/docuchango/cli.py
+++ b/docuchango/cli.py
@@ -519,19 +519,10 @@ def bootstrap(guide: str, output: Path | None):
 
     # Try to find the guide in the package
     try:
-        # First, try to find it in the installed package
         import importlib.resources as resources
 
-        try:
-            # Python 3.9+
-            guide_path = resources.files("docuchango") / ".." / "docs" / guide_file
-            guide_content = guide_path.read_text()
-        except AttributeError:
-            # Python 3.8 fallback
-            with resources.path("docuchango", "__init__.py") as pkg_path:
-                docs_dir = pkg_path.parent.parent / "docs"
-                guide_path = docs_dir / guide_file
-                guide_content = guide_path.read_text()
+        guide_path = resources.files("docuchango") / ".." / "docs" / guide_file
+        guide_content = guide_path.read_text()
 
     except (FileNotFoundError, ModuleNotFoundError):
         # Fallback: try relative to the script location

--- a/docuchango/fixes/docs.py
+++ b/docuchango/fixes/docs.py
@@ -23,7 +23,7 @@ def fix_trailing_whitespace(file_path: Path) -> int:
     fixed_lines = [line.rstrip() + ("\n" if line.endswith("\n") else "") for line in lines]
 
     # Count changes
-    changes = sum(1 for old, new in zip(lines, fixed_lines) if old != new)
+    changes = sum(1 for old, new in zip(lines, fixed_lines, strict=True) if old != new)
 
     if changes > 0:
         file_path.write_text("".join(fixed_lines))

--- a/docuchango/fixes/frontmatter.py
+++ b/docuchango/fixes/frontmatter.py
@@ -10,7 +10,6 @@ import re
 import uuid
 from datetime import datetime
 from pathlib import Path
-from typing import Optional
 
 import frontmatter
 
@@ -57,7 +56,7 @@ STATUS_MAPPINGS = {
 }
 
 
-def get_doc_type(file_path: Path) -> Optional[str]:
+def get_doc_type(file_path: Path) -> str | None:
     """Extract document type from file path.
 
     Args:

--- a/docuchango/fixes/timestamps.py
+++ b/docuchango/fixes/timestamps.py
@@ -45,7 +45,7 @@ def get_git_dates(file_path: Path) -> tuple[str | None, str | None]:
             return None, None
 
         first_commit = commits[0]
-        # Replace 'Z' with '+00:00' for Python 3.9/3.10 compatibility (Python 3.11+ handles 'Z' natively)
+        # Replace 'Z' with '+00:00' for Python 3.10 compatibility (Python 3.11+ handles 'Z' natively)
         first_commit = first_commit.replace("Z", "+00:00")
         # Convert to UTC and format as ISO 8601 datetime
         created_dt = datetime.fromisoformat(first_commit).astimezone(timezone.utc)
@@ -63,7 +63,7 @@ def get_git_dates(file_path: Path) -> tuple[str | None, str | None]:
         if not last_commit:
             return created_datetime, created_datetime
 
-        # Replace 'Z' with '+00:00' for Python 3.9/3.10 compatibility (Python 3.11+ handles 'Z' natively)
+        # Replace 'Z' with '+00:00' for Python 3.10 compatibility (Python 3.11+ handles 'Z' natively)
         last_commit = last_commit.replace("Z", "+00:00")
         # Convert to UTC and format as ISO 8601 datetime
         updated_dt = datetime.fromisoformat(last_commit).astimezone(timezone.utc)

--- a/docuchango/readability.py
+++ b/docuchango/readability.py
@@ -27,7 +27,6 @@ Usage:
 
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Optional
 
 try:
     import textstat  # type: ignore[import-untyped]
@@ -76,14 +75,14 @@ class ReadabilityConfig:
 
     enabled: bool = True
     # Flesch Reading Ease: minimum score (higher = easier)
-    flesch_reading_ease_min: Optional[float] = 60.0
+    flesch_reading_ease_min: float | None = 60.0
     # Grade-level metrics: maximum grade level (lower = easier)
-    flesch_kincaid_grade_max: Optional[float] = 10.0
-    gunning_fog_max: Optional[float] = 12.0
-    smog_index_max: Optional[float] = 12.0
-    automated_readability_index_max: Optional[float] = 10.0
-    coleman_liau_index_max: Optional[float] = 10.0
-    dale_chall_max: Optional[float] = 9.0
+    flesch_kincaid_grade_max: float | None = 10.0
+    gunning_fog_max: float | None = 12.0
+    smog_index_max: float | None = 12.0
+    automated_readability_index_max: float | None = 10.0
+    coleman_liau_index_max: float | None = 10.0
+    dale_chall_max: float | None = 9.0
     # Minimum paragraph length to analyze (in characters)
     min_paragraph_length: int = 100
 
@@ -94,14 +93,14 @@ class ParagraphScore:
 
     paragraph_text: str
     line_number: int
-    flesch_reading_ease: Optional[float] = None
-    flesch_kincaid_grade: Optional[float] = None
-    gunning_fog: Optional[float] = None
-    smog_index: Optional[float] = None
-    automated_readability_index: Optional[float] = None
-    coleman_liau_index: Optional[float] = None
-    dale_chall: Optional[float] = None
-    text_standard: Optional[str] = None
+    flesch_reading_ease: float | None = None
+    flesch_kincaid_grade: float | None = None
+    gunning_fog: float | None = None
+    smog_index: float | None = None
+    automated_readability_index: float | None = None
+    coleman_liau_index: float | None = None
+    dale_chall: float | None = None
+    text_standard: str | None = None
     errors: list[str] = field(default_factory=list)
 
     def has_errors(self) -> bool:

--- a/docuchango/validator.py
+++ b/docuchango/validator.py
@@ -29,7 +29,7 @@ from dataclasses import dataclass, field
 from datetime import date, datetime
 from enum import Enum
 from pathlib import Path
-from typing import Any, Optional, cast
+from typing import Any, cast
 
 try:
     import frontmatter
@@ -97,7 +97,7 @@ class Document:
     doc_uuid: str = ""  # Frontmatter doc_uuid field (UUID v4)
     links: list["Link"] = field(default_factory=list)
     errors: list[str] = field(default_factory=list)
-    _content_cache: Optional[str] = None  # Cached file content to avoid multiple reads
+    _content_cache: str | None = None  # Cached file content to avoid multiple reads
 
     def __hash__(self):
         return hash(str(self.file_path))
@@ -150,11 +150,11 @@ class DocValidator:
         self.errors: list[str] = []
 
         # Load project configuration
-        self.project_config_path: Optional[Path] = None
+        self.project_config_path: Path | None = None
         self.project_config = self._load_project_config()
         self.project_configs = self._load_project_config_contexts()
 
-    def _load_project_config(self) -> Optional[DocsProjectConfig]:
+    def _load_project_config(self) -> DocsProjectConfig | None:
         """Load docs-project.yaml configuration"""
         candidate_paths = [
             self.repo_root / "docs-project.yaml",
@@ -182,7 +182,7 @@ class DocValidator:
         self.log("⚠️  Warning: Project config not found (looked for docs-project.yaml at repo root and docs-cms/)")
         return None
 
-    def _load_project_config_at(self, config_path: Path) -> Optional[DocsProjectConfig]:
+    def _load_project_config_at(self, config_path: Path) -> DocsProjectConfig | None:
         """Load one docs-project.yaml file from an explicit path."""
         if not config_path.exists():
             self.log(
@@ -440,7 +440,7 @@ class DocValidator:
 
         self.log(f"   Found {len(self.documents)} documents")
 
-    def _parse_document(self, file_path: Path, doc_type: str, require_frontmatter: bool = True) -> Optional[Document]:
+    def _parse_document(self, file_path: Path, doc_type: str, require_frontmatter: bool = True) -> Document | None:
         """Parse a markdown file and validate frontmatter"""
         return self._parse_document_enhanced(file_path, doc_type, require_frontmatter=require_frontmatter)
 
@@ -454,7 +454,7 @@ class DocValidator:
 
     def _parse_document_enhanced(
         self, file_path: Path, doc_type: str, require_frontmatter: bool = True
-    ) -> Optional[Document]:
+    ) -> Document | None:
         """Parse document with python-frontmatter and pydantic validation"""
         try:
             # Read file content once and cache it
@@ -866,7 +866,7 @@ class DocValidator:
 
         return headings
 
-    def _bucket_for_target(self, target_path: Path, bucket_config) -> Optional[str]:
+    def _bucket_for_target(self, target_path: Path, bucket_config) -> str | None:
         """Compute the expected index bucket for a target document."""
         post = frontmatter.loads(target_path.read_text(encoding="utf-8"))
 
@@ -977,7 +977,7 @@ class DocValidator:
         sorted_headings = sorted(headings.items())
         buckets = set(headings.values())
 
-        def bucket_at_line(line_num: int) -> Optional[str]:
+        def bucket_at_line(line_num: int) -> str | None:
             current = None
             for heading_line, heading in sorted_headings:
                 if heading_line >= line_num:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Topic :: Documentation",
     "Topic :: Software Development :: Testing",
     "Topic :: Software Development :: Quality Assurance",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -139,7 +139,7 @@ exclude_lines = [
 ]
 
 [tool.ruff]
-target-version = "py39"
+target-version = "py310"
 line-length = 120
 
 [tool.ruff.lint]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,7 @@ import random
 import string
 import uuid
 from datetime import datetime, timedelta
-from typing import Any, Optional
+from typing import Any
 
 import pytest
 
@@ -90,10 +90,10 @@ class MarkdownGenerator:
 
     @staticmethod
     def frontmatter(
-        title: Optional[str] = None,
-        doc_id: Optional[str] = None,
-        project_id: Optional[str] = None,
-        doc_uuid: Optional[str] = None,
+        title: str | None = None,
+        doc_id: str | None = None,
+        project_id: str | None = None,
+        doc_uuid: str | None = None,
         **kwargs: Any,
     ) -> str:
         """Generate frontmatter YAML."""
@@ -140,14 +140,14 @@ class MarkdownGenerator:
         return " ".join(paragraph_lines)
 
     @staticmethod
-    def heading(level: int = 2, text: Optional[str] = None) -> str:
+    def heading(level: int = 2, text: str | None = None) -> str:
         """Generate a heading."""
         gen = DataGenerator()
         text = text or gen.random_title()
         return f"{'#' * level} {text}"
 
     @staticmethod
-    def link(text: Optional[str] = None, url: Optional[str] = None) -> str:
+    def link(text: str | None = None, url: str | None = None) -> str:
         """Generate a markdown link."""
         gen = DataGenerator()
         text = text or gen.random_title(2)

--- a/tests/test_bulk_update_comprehensive.py
+++ b/tests/test_bulk_update_comprehensive.py
@@ -338,7 +338,7 @@ class TestBulkUpdateFilesEdgeCases:
         assert all(changed for _, changed, _ in results)
 
         # But no files should be modified
-        for f, original in zip(files, originals):
+        for f, original in zip(files, originals, strict=True):
             assert f.read_text() == original
 
     def test_bulk_remove_all_fields(self, tmp_path):
@@ -373,7 +373,7 @@ class TestBulkUpdateFilesEdgeCases:
         assert all(changed for _, changed, _ in results)
 
         # Verify values preserved
-        for f, expected_value in zip(files, values):
+        for f, expected_value in zip(files, values, strict=True):
             post = frontmatter.loads(f.read_text())
             assert post.metadata["new_name"] == expected_value
 


### PR DESCRIPTION
## Summary
- Update docs and badges to advertise Python 3.10+ support only, including Python 3.14.
- Add Python 3.14 to project classifiers and CI test matrix.
- Run lint, build, and Codecov upload on Python 3.14.
- Move Ruff target from py39 to py310 and apply the resulting Python 3.10 cleanup.
- Remove obsolete importlib.resources fallback code for unsupported Python versions.
- Update timestamp compatibility comments to reference Python 3.10 only.

## Coverage
- uv lock --upgrade --dry-run
- uv run --all-extras --python 3.14 ruff format --check .
- uv run ruff check . --output-format=github
- uv run mypy docuchango tests
- uv run pytest
- uv build
- uv tool run twine check dist/*
- actionlint

Base: stacked on #58 / chore/dependency-audit.