### PR TITLE
fix: tighten validation and repair flows

### DIFF
--- a/docuchango/cli.py
+++ b/docuchango/cli.py
@@ -186,10 +186,8 @@ def validate(
     - Consistent ADR/RFC numbering
     """
     from docuchango.fixes.code_blocks import fix_code_blocks
-    from docuchango.fixes.frontmatter import fix_all_frontmatter
-    from docuchango.fixes.tags import fix_tags
+    from docuchango.fixes.frontmatter import fix_frontmatter_metadata
     from docuchango.fixes.timestamps import update_document_timestamps
-    from docuchango.fixes.whitespace import fix_whitespace_and_fields
 
     try:
         from docuchango.validator import DocValidator
@@ -209,53 +207,57 @@ def validate(
 
     # Phase 1: Apply automatic fixes
     if all_files:
-        # Define fix functions: (name, function, supports_dry_run)
-        fix_types = [
-            ("Frontmatter", fix_all_frontmatter, True),
-            ("Tags", fix_tags, True),
-            ("Whitespace", fix_whitespace_and_fields, True),
-            ("Timestamps", update_document_timestamps, True),
-            ("Code blocks", fix_code_blocks, False),
-        ]
+        for file_path in all_files:
+            try:
+                changed, messages = fix_frontmatter_metadata(file_path, dry_run=dry_run)
+                if changed and messages:
+                    for msg in messages:
+                        fixes_applied.append((file_path, f"[Frontmatter metadata] {msg}"))
+            except Exception as e:
+                if verbose:
+                    rel_path = file_path.relative_to(repo_root)
+                    console.print(f"  [red]✗[/red] {rel_path}: Error in Frontmatter metadata - {e}")
 
-        for fix_name, fix_func, supports_dry_run_flag in fix_types:
-            for file_path in all_files:
+            try:
+                changed, messages = update_document_timestamps(file_path, dry_run=dry_run)
+                if changed and messages:
+                    for msg in messages:
+                        fixes_applied.append((file_path, f"[Timestamps] {msg}"))
+            except Exception as e:
+                if verbose:
+                    rel_path = file_path.relative_to(repo_root)
+                    console.print(f"  [red]✗[/red] {rel_path}: Error in Timestamps - {e}")
+
+            if not dry_run:
                 try:
-                    # Skip code blocks fix in dry_run mode since it doesn't support it
-                    if not supports_dry_run_flag and dry_run:
-                        continue
-
-                    # Call the fix function
-                    result = fix_func(file_path, dry_run=dry_run) if supports_dry_run_flag else fix_func(file_path)
-
-                    # Handle different return types
-                    if isinstance(result, list):
-                        messages = result
-                        changed = bool(messages)
-                    else:
-                        changed, messages = result
-
+                    changed, messages = fix_code_blocks(file_path)
                     if changed and messages:
                         for msg in messages:
-                            fixes_applied.append((file_path, f"[{fix_name}] {msg}"))
-
+                            fixes_applied.append((file_path, f"[Code blocks] {msg}"))
                 except Exception as e:
                     if verbose:
                         rel_path = file_path.relative_to(repo_root)
-                        console.print(f"  [red]✗[/red] {rel_path}: Error in {fix_name} - {e}")
+                        console.print(f"  [red]✗[/red] {rel_path}: Error in Code blocks - {e}")
 
     # Phase 2: Run validation to find remaining issues
     try:
         # Don't pass fix=True to validator since we already applied fixes above
         validator = DocValidator(repo_root=repo_root, verbose=verbose, fix=False)
         validator.scan_documents()
+        validator.extract_links()
+        validator.validate_links()
+        validator.check_ids()
+        validator.check_uuids()
         validator.check_code_blocks()
+        validator.check_mdx_compilation()
+        validator.check_mdx_compatibility()
+        validator.check_cross_plugin_links()
+        validator.check_document_indexes()
         validator.check_formatting()
+        validator.check_readability()
 
-        # Check if we should run build validation
-        if not skip_build:
-            # This would need to be implemented based on the validate_docs.py logic
-            pass
+        build_passed = validator.check_typescript_config()
+        build_passed = validator.check_docusaurus_build(skip_build) and build_passed
 
         # Collect remaining errors
         for doc in validator.documents:
@@ -263,8 +265,20 @@ def validate(
                 for error in doc.errors:
                     remaining_issues.append((doc.file_path, error))
 
+        for link in validator.all_links:
+            if not link.is_valid:
+                remaining_issues.append(
+                    (
+                        link.source_doc,
+                        f"Line {link.line_number}: Broken link '{link.target}' - {link.error_message}",
+                    )
+                )
+
         for error in validator.errors:
             remaining_issues.append((repo_root, error))
+
+        if not build_passed and not validator.errors:
+            remaining_issues.append((repo_root, "Build validation failed"))
 
     except Exception as e:
         console.print(f"[bold red]Error during validation: {e}[/bold red]")

--- a/docuchango/fixes/frontmatter.py
+++ b/docuchango/fixes/frontmatter.py
@@ -8,24 +8,30 @@ This module provides fixes for common frontmatter problems:
 
 import re
 import uuid
-from datetime import datetime
+from datetime import date, datetime
 from pathlib import Path
 
 import frontmatter
 
+from docuchango.fixes.tags import normalize_tag
+from docuchango.fixes.whitespace import ensure_required_fields, normalize_empty_values, trim_string_values
 from docuchango.fixes.yaml_utils import dumps as frontmatter_dumps
 
 # Valid status values by document type
 VALID_STATUSES = {
-    "adr": ["Proposed", "Accepted", "Deprecated", "Superseded"],
-    "rfc": ["Draft", "In Review", "Accepted", "Rejected", "Implemented"],
-    "memo": ["Draft", "Published", "Archived"],
+    "adr": ["Proposed", "Accepted", "Implemented", "Deprecated", "Superseded"],
+    "rfc": ["Draft", "Proposed", "Accepted", "Implemented", "Deprecated", "Superseded"],
     "prd": ["Draft", "In Review", "Approved", "In Progress", "Completed", "Cancelled"],
 }
 
 # Common status value mappings (incorrect -> correct)
 STATUS_MAPPINGS = {
     "adr": {
+        "proposed": "Proposed",
+        "accepted": "Accepted",
+        "implemented": "Implemented",
+        "deprecated": "Deprecated",
+        "superseded": "Superseded",
         "draft": "Proposed",
         "pending": "Proposed",
         "active": "Accepted",
@@ -34,24 +40,32 @@ STATUS_MAPPINGS = {
         "replaced": "Superseded",
     },
     "rfc": {
-        "proposed": "Draft",
-        "pending": "In Review",
+        "draft": "Draft",
+        "proposed": "Proposed",
+        "accepted": "Accepted",
+        "implemented": "Implemented",
+        "deprecated": "Deprecated",
+        "superseded": "Superseded",
+        "pending": "Proposed",
+        "review": "Proposed",
+        "in review": "Proposed",
         "approved": "Accepted",
         "done": "Implemented",
-        "declined": "Rejected",
-    },
-    "memo": {
-        "pending": "Draft",
-        "public": "Published",
-        "retired": "Archived",
+        "retired": "Deprecated",
+        "replaced": "Superseded",
     },
     "prd": {
+        "draft": "Draft",
+        "in review": "In Review",
+        "approved": "Approved",
+        "in progress": "In Progress",
+        "completed": "Completed",
+        "cancelled": "Cancelled",
         "proposed": "Draft",
         "review": "In Review",
         "active": "In Progress",
         "done": "Completed",
         "closed": "Completed",
-        "cancelled": "Cancelled",
     },
 }
 
@@ -108,6 +122,8 @@ def fix_status_value(file_path: Path, dry_run: bool = False) -> tuple[bool, str]
 
         # Check if already valid
         valid_statuses = VALID_STATUSES.get(doc_type, [])
+        if not valid_statuses:
+            return False, f"No status validation configured for document type '{doc_type}'"
         if status in valid_statuses:
             return False, "Status already valid"
 
@@ -261,11 +277,10 @@ def add_missing_frontmatter(file_path: Path, dry_run: bool = False) -> tuple[boo
         if not doc_type:
             return False, "Could not determine document type"
 
-        # Extract ID from filename (e.g., "adr-001" from "adr-001-some-title.md")
-        # Fallback: generate a valid ID using doc_type and a short UUID if no match
+        # Extract ID from filename (e.g., "adr-001" from "adr-001-some-title.md").
         filename = file_path.stem
-        id_match = re.match(r"^([a-zA-Z]+-\d+)", filename)
-        doc_id = id_match.group(1) if id_match else f"{doc_type}-{uuid.uuid4().hex[:8]}"
+        id_match = re.match(rf"^({doc_type})-(\d+)", filename, re.IGNORECASE)
+        doc_id = f"{doc_type}-{int(id_match.group(2)):03d}" if id_match else f"{doc_type}-001"
 
         # Generate title from filename
         title_parts = filename.replace("-", " ").split()
@@ -285,8 +300,7 @@ def add_missing_frontmatter(file_path: Path, dry_run: bool = False) -> tuple[boo
             "---",
             f'id: "{doc_id}"',
             f'title: "{title}"',
-            f"status: {default_status}",
-            f"date: {today}",
+            f"created: {today}",
             "tags: []",
             'project_id: "my-project"',
             f'doc_uuid: "{doc_uuid}"',
@@ -294,7 +308,17 @@ def add_missing_frontmatter(file_path: Path, dry_run: bool = False) -> tuple[boo
 
         # Add document-type-specific fields
         if doc_type == "adr":
+            frontmatter_lines.insert(3, f"status: {default_status}")
             frontmatter_lines.insert(-2, 'deciders: "Engineering Team"')
+        elif doc_type == "rfc":
+            frontmatter_lines.insert(3, f"status: {default_status}")
+            frontmatter_lines.insert(-2, 'author: "Engineering Team"')
+        elif doc_type == "memo":
+            frontmatter_lines.insert(-2, 'author: "Engineering Team"')
+        elif doc_type == "prd":
+            frontmatter_lines.insert(3, f"status: {default_status}")
+            frontmatter_lines.insert(-2, 'author: "Product Team"')
+            frontmatter_lines.insert(-2, 'target_release: "TBD"')
 
         frontmatter_lines.append("---")
         frontmatter_block = "\n".join(frontmatter_lines)
@@ -349,3 +373,184 @@ def fix_all_frontmatter(file_path: Path, dry_run: bool = False) -> list[str]:
         messages.append(f"✓ {msg}")
 
     return messages
+
+
+def _fix_status_metadata(metadata: dict, doc_type: str | None) -> str | None:
+    """Normalize status in already-parsed metadata."""
+    if "status" not in metadata:
+        return None
+    if not doc_type:
+        return None
+
+    status = metadata["status"]
+    if not isinstance(status, str) or not status.strip():
+        return None
+
+    valid_statuses = VALID_STATUSES.get(doc_type, [])
+    if status in valid_statuses:
+        return None
+
+    mappings = STATUS_MAPPINGS.get(doc_type, {})
+    status_lower = status.lower().strip()
+    if status_lower in mappings:
+        new_status = mappings[status_lower]
+        metadata["status"] = new_status
+        return f"Changed status from '{status}' to '{new_status}'"
+
+    for key, value in mappings.items():
+        if key in status_lower or status_lower in key:
+            metadata["status"] = value
+            return f"Changed status from '{status}' to '{value}'"
+
+    return None
+
+
+def _fix_date_metadata(metadata: dict, content: str) -> str | None:
+    """Normalize date or created in already-parsed metadata."""
+    if "date" in metadata:
+        date_field = "date"
+    elif "created" in metadata:
+        date_field = "created"
+    else:
+        return None
+
+    date_value = metadata[date_field]
+
+    if isinstance(date_value, (datetime, date)):
+        raw_lines = content.split("---")[1].strip().splitlines() if "---" in content else []
+        raw_value = None
+        for line in raw_lines:
+            if line.startswith(f"{date_field}:"):
+                raw_value = line.split(":", 1)[1].strip()
+                break
+        canonical_re = re.compile(r"^\d{4}-\d{2}-\d{2}(T\d{2}:\d{2}:\d{2}Z?)?$")
+        if raw_value and canonical_re.match(raw_value):
+            return None
+        return f"Normalized {date_field} object to canonical format"
+
+    if not isinstance(date_value, str):
+        return None
+
+    if re.match(
+        r"^\d{4}-\d{2}-\d{2}(T\d{2}:\d{2}:\d{2}(Z|[+-]\d{2}:\d{2})?)?$",
+        date_value,
+    ):
+        return None
+
+    formats = [
+        "%Y/%m/%d",
+        "%d/%m/%Y",
+        "%m/%d/%Y",
+        "%Y.%m.%d",
+        "%d.%m.%Y",
+        "%B %d, %Y",
+        "%b %d, %Y",
+        "%d %B %Y",
+        "%d %b %Y",
+    ]
+
+    for fmt in formats:
+        try:
+            parsed_date = datetime.strptime(date_value, fmt)
+        except ValueError:
+            continue
+        iso_date = parsed_date.strftime("%Y-%m-%d")
+        metadata[date_field] = iso_date
+        return f"Converted {date_field} from '{date_value}' to '{iso_date}'"
+
+    return None
+
+
+def _fix_tags_metadata(metadata: dict) -> list[str]:
+    """Normalize tags in already-parsed metadata."""
+    messages = []
+    if "tags" not in metadata:
+        metadata["tags"] = []
+        return ["Added missing tags field (empty array)"]
+
+    tags = metadata["tags"]
+    if isinstance(tags, str):
+        tags = [tags.strip()] if tags.strip() else []
+        messages.append("Converted string tags to array")
+    if not isinstance(tags, list):
+        return messages
+
+    original_tags = tags.copy()
+    normalized_tags = []
+    for tag in tags:
+        if not isinstance(tag, str):
+            messages.append(f"Skipped non-string tag: {tag}")
+            continue
+        normalized = normalize_tag(tag)
+        if normalized:
+            normalized_tags.append(normalized)
+
+    unique_tags = []
+    seen = set()
+    for tag in normalized_tags:
+        if tag not in seen:
+            seen.add(tag)
+            unique_tags.append(tag)
+
+    sorted_tags = sorted(unique_tags)
+    if sorted_tags != original_tags:
+        if len(sorted_tags) < len(original_tags):
+            messages.append(f"Removed {len(original_tags) - len(sorted_tags)} duplicate/invalid tags")
+        if sorted_tags != normalized_tags:
+            messages.append("Sorted tags alphabetically")
+        if normalized_tags != original_tags:
+            messages.append(f"Normalized tags: {len(normalized_tags)} tags")
+    metadata["tags"] = sorted_tags
+    return messages
+
+
+def fix_frontmatter_metadata(file_path: Path, dry_run: bool = False) -> tuple[bool, list[str]]:
+    """Apply frontmatter metadata fixes with a single parse/write pass."""
+    try:
+        content = file_path.read_text(encoding="utf-8")
+    except UnicodeDecodeError as e:
+        raise ValueError(f"File contains binary content: {e}") from e
+    except Exception as e:
+        return False, [f"Error reading file: {e}"]
+
+    try:
+        post = frontmatter.loads(content)
+    except Exception as e:
+        return False, [f"Error parsing frontmatter: {e}"]
+
+    if not post.metadata:
+        changed, message = add_missing_frontmatter(file_path, dry_run=dry_run)
+        return (changed, [message] if changed else [])
+
+    metadata = post.metadata.copy()
+    original_metadata = metadata.copy()
+    messages = []
+
+    status_message = _fix_status_metadata(metadata, get_doc_type(file_path))
+    if status_message:
+        messages.append(status_message)
+
+    date_message = _fix_date_metadata(metadata, content)
+    force_write = date_message is not None and metadata == original_metadata
+    if date_message:
+        messages.append(date_message)
+
+    messages.extend(_fix_tags_metadata(metadata))
+
+    metadata, trim_messages = trim_string_values(metadata)
+    messages.extend(trim_messages)
+
+    metadata, empty_messages = normalize_empty_values(metadata)
+    messages.extend(empty_messages)
+
+    metadata, required_messages = ensure_required_fields(metadata)
+    messages.extend(required_messages)
+
+    changed = metadata != original_metadata or force_write
+    if changed:
+        post.metadata = metadata
+        if not dry_run:
+            file_path.write_text(frontmatter_dumps(post), encoding="utf-8")
+        return True, messages
+
+    return False, []

--- a/docuchango/fixes/id_compression.py
+++ b/docuchango/fixes/id_compression.py
@@ -87,6 +87,7 @@ def compress_document_ids(
     """
     repo_root = repo_root.resolve()
     changes = _plan_id_changes(doc_files, doc_type)
+    _validate_document_changes(changes)
     result = CompressionResult(changes=changes)
 
     updated_files = _rewrite_references(repo_root, changes, dry_run=dry_run)
@@ -101,6 +102,22 @@ def compress_document_ids(
     )
     result.missing_references = audit_missing_document_references(repo_root, doc_files, planned_changes=changes)
     return result
+
+
+def _validate_document_changes(changes: list[DocumentIdChange]) -> None:
+    """Fail before rewriting references if planned renames cannot be applied safely."""
+    source_paths = {change.file_path for change in changes}
+    destination_paths: set[Path] = set()
+
+    for change in changes:
+        if change.new_path in destination_paths:
+            raise FileExistsError(f"Cannot rename documents: duplicate destination {change.new_path}")
+        destination_paths.add(change.new_path)
+
+        if change.file_path == change.new_path:
+            continue
+        if change.new_path.exists() and change.new_path not in source_paths:
+            raise FileExistsError(f"Cannot rename {change.file_path} to {change.new_path}: destination exists")
 
 
 def audit_missing_document_references(

--- a/docuchango/validator.py
+++ b/docuchango/validator.py
@@ -94,6 +94,7 @@ class Document:
     date: str = ""
     tags: list[str] = field(default_factory=list)
     doc_id: str = ""  # Frontmatter id field (e.g., "adr-001", "rfc-015")
+    expected_id: str | None = None  # ID inferred from configured filename pattern, when available
     doc_uuid: str = ""  # Frontmatter doc_uuid field (UUID v4)
     links: list["Link"] = field(default_factory=list)
     errors: list[str] = field(default_factory=list)
@@ -378,14 +379,17 @@ class DocValidator:
                 self.log(f"   ✗ {md_file.name}: Invalid filename format")
                 continue
 
+            expected_id = None
             if match and len(match.groups()) >= 2:
-                _prefix, num = match.groups()[:2]
+                prefix, num = match.groups()[:2]
                 # Skip template files (000)
                 if num == "000":
                     self.log(f"   ⊘ {md_file.name}: Skipping template file")
                     continue
+                if isinstance(prefix, str) and isinstance(num, str) and prefix.lower() == doc_type and num.isdigit():
+                    expected_id = f"{doc_type}-{num}"
 
-            doc = self._parse_document(md_file, doc_type, require_frontmatter=require_frontmatter)
+            doc = self._parse_document(md_file, doc_type, require_frontmatter=require_frontmatter, expected_id=expected_id)
             if doc:
                 self.documents.append(doc)
                 self.file_to_doc[md_file] = doc
@@ -440,9 +444,13 @@ class DocValidator:
 
         self.log(f"   Found {len(self.documents)} documents")
 
-    def _parse_document(self, file_path: Path, doc_type: str, require_frontmatter: bool = True) -> Document | None:
+    def _parse_document(
+        self, file_path: Path, doc_type: str, require_frontmatter: bool = True, expected_id: str | None = None
+    ) -> Document | None:
         """Parse a markdown file and validate frontmatter"""
-        return self._parse_document_enhanced(file_path, doc_type, require_frontmatter=require_frontmatter)
+        return self._parse_document_enhanced(
+            file_path, doc_type, require_frontmatter=require_frontmatter, expected_id=expected_id
+        )
 
     def _infer_plain_markdown_title(self, file_path: Path, content: str) -> str:
         """Infer a title for plain-markdown generic documents."""
@@ -453,7 +461,7 @@ class DocValidator:
         return file_path.stem.replace("-", " ").replace("_", " ").strip().title() or file_path.name
 
     def _parse_document_enhanced(
-        self, file_path: Path, doc_type: str, require_frontmatter: bool = True
+        self, file_path: Path, doc_type: str, require_frontmatter: bool = True, expected_id: str | None = None
     ) -> Document | None:
         """Parse document with python-frontmatter and pydantic validation"""
         try:
@@ -468,11 +476,23 @@ class DocValidator:
                 if doc_type == "generic" and not require_frontmatter:
                     title = self._infer_plain_markdown_title(file_path, content)
                     self.log(f"   ✓ {file_path.name}: Plain Markdown generic doc")
-                    return Document(file_path=file_path, doc_type=doc_type, title=title, _content_cache=content)
+                    return Document(
+                        file_path=file_path,
+                        doc_type=doc_type,
+                        title=title,
+                        expected_id=expected_id,
+                        _content_cache=content,
+                    )
 
                 error = "Missing YAML frontmatter"
                 self.log(f"   ✗ {file_path.name}: {error}")
-                doc = Document(file_path=file_path, doc_type=doc_type, title="Unknown", _content_cache=content)
+                doc = Document(
+                    file_path=file_path,
+                    doc_type=doc_type,
+                    title="Unknown",
+                    expected_id=expected_id,
+                    _content_cache=content,
+                )
                 doc.errors.append(error)
                 return doc
 
@@ -500,6 +520,7 @@ class DocValidator:
                     date=str(metadata.get("date", metadata.get("created", ""))),
                     tags=metadata.get("tags", []),
                     doc_id=metadata.get("id", ""),
+                    expected_id=expected_id,
                     _content_cache=content,
                 )
 
@@ -528,6 +549,7 @@ class DocValidator:
                 date=str(metadata.get("date", metadata.get("created", ""))),
                 tags=metadata.get("tags", []),
                 doc_id=metadata.get("id", ""),
+                expected_id=expected_id,
                 doc_uuid=metadata.get("doc_uuid", ""),
                 _content_cache=content,
             )
@@ -1433,24 +1455,10 @@ class DocValidator:
 
             # Extract expected ID from filename
             filename = doc.file_path.name
-            # Match adr-XXX, rfc-XXX, or memo-XXX pattern (lowercase only)
-            filename_pattern = re.compile(r"^(adr|rfc|memo|prd)-(\d{3})-")
-            match = filename_pattern.match(filename)
-
-            if not match:
-                # This shouldn't happen (caught in scan_documents), but check anyway
-                error = f"Filename doesn't match expected pattern ({doc.doc_type}-NNN-title.md)"
-                doc.errors.append(error)
-                self.log(f"   ✗ {filename}: {error}")
-                id_errors += 1
-                continue
-
-            _prefix, num = match.groups()
-            expected_id = f"{doc.doc_type}-{num}"
 
             # Check ID matches filename
-            if doc.doc_id != expected_id:
-                error = f"ID mismatch: frontmatter has '{doc.doc_id}' but filename suggests '{expected_id}'"
+            if doc.expected_id and doc.doc_id != doc.expected_id:
+                error = f"ID mismatch: frontmatter has '{doc.doc_id}' but filename suggests '{doc.expected_id}'"
                 doc.errors.append(error)
                 self.log(f"   ✗ {filename}: {error}")
                 id_errors += 1
@@ -1494,7 +1502,7 @@ class DocValidator:
 
         for doc in self.documents:
             # Skip docs without doc_type (generic docs) or without UUID
-            if doc.doc_type not in ["adr", "rfc", "memo"] or not doc.doc_uuid:
+            if doc.doc_type not in ["adr", "rfc", "memo", "prd"] or not doc.doc_uuid:
                 continue
 
             # Check for duplicate UUIDs

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -1,6 +1,7 @@
 """Tests for CLI commands in cli.py to improve coverage."""
 
 import subprocess
+from pathlib import Path
 
 import frontmatter
 from click.testing import CliRunner
@@ -183,6 +184,49 @@ tags: "API Design"
             "File was modified during --dry-run! Dry run should not modify any files."
         )
 
+    def test_validate_writes_frontmatter_metadata_once(self, tmp_path, monkeypatch):
+        """Frontmatter metadata fixes should be batched into one write per file."""
+        adr_dir = tmp_path / "adr"
+        adr_dir.mkdir()
+
+        test_file = adr_dir / "adr-001-batched-fixes.md"
+        test_file.write_text(
+            """---
+id: adr-001
+title: "Batched Metadata Fixes  "
+status: accepted
+created: 2025-01-01
+deciders: Core Team
+tags: "API Design"
+project_id: test-project
+doc_uuid: 12345678-1234-4123-8123-123456789abc
+---
+
+# Batched Metadata Fixes
+""",
+            encoding="utf-8",
+        )
+
+        original_write_text = Path.write_text
+        writes = []
+
+        def counting_write_text(self, *args, **kwargs):
+            if self == test_file:
+                writes.append(args[0])
+            return original_write_text(self, *args, **kwargs)
+
+        monkeypatch.setattr(Path, "write_text", counting_write_text)
+
+        runner = CliRunner()
+        result = runner.invoke(validate, ["--repo-root", str(tmp_path), "--skip-build"])
+
+        assert result.exit_code == 0
+        assert len(writes) == 1
+        fixed_content = test_file.read_text(encoding="utf-8")
+        assert "status: Accepted" in fixed_content
+        assert "api-design" in fixed_content
+        assert 'title: "Batched Metadata Fixes  "' not in fixed_content
+
     def test_validate_output_shows_fixes_and_issues_with_paths(self, tmp_path):
         """Test that validate output shows both fixed and unfixable issues with file paths.
 
@@ -265,6 +309,86 @@ more code
         assert "tags:" in fixed_content
         # Original string format should be gone
         assert 'tags: "API Design, Database"' not in fixed_content
+
+    def test_validate_reports_broken_links(self, tmp_path):
+        """Regression test: CLI validate must run link validation."""
+        adr_dir = tmp_path / "docs-cms" / "adr"
+        adr_dir.mkdir(parents=True)
+
+        test_file = adr_dir / "adr-001-broken-link.md"
+        test_file.write_text(
+            """---
+id: adr-001
+title: Valid ADR Title
+status: Accepted
+created: 2025-01-01
+deciders: Core Team
+tags: []
+project_id: test-project
+doc_uuid: 12345678-1234-4123-8123-123456789abc
+---
+
+# Valid ADR Title
+
+[Missing document](./missing.md)
+""",
+            encoding="utf-8",
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(validate, ["--repo-root", str(tmp_path), "--skip-build", "--dry-run"])
+
+        assert result.exit_code == 1
+        assert "adr-001-broken-link.md" in result.output
+        assert "Broken link './missing.md'" in result.output
+
+    def test_validate_reports_duplicate_ids(self, tmp_path):
+        """Regression test: CLI validate must run document ID validation."""
+        adr_dir = tmp_path / "docs-cms" / "adr"
+        adr_dir.mkdir(parents=True)
+
+        first_file = adr_dir / "adr-001-first.md"
+        first_file.write_text(
+            """---
+id: adr-001
+title: First ADR Title
+status: Accepted
+created: 2025-01-01
+deciders: Core Team
+tags: []
+project_id: test-project
+doc_uuid: 12345678-1234-4123-8123-123456789abc
+---
+
+# First ADR Title
+""",
+            encoding="utf-8",
+        )
+
+        second_file = adr_dir / "adr-002-second.md"
+        second_file.write_text(
+            """---
+id: adr-001
+title: Second ADR Title
+status: Accepted
+created: 2025-01-02
+deciders: Core Team
+tags: []
+project_id: test-project
+doc_uuid: 12345678-1234-4123-8123-123456789abd
+---
+
+# Second ADR Title
+""",
+            encoding="utf-8",
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(validate, ["--repo-root", str(tmp_path), "--skip-build", "--dry-run"])
+
+        assert result.exit_code == 1
+        assert "adr-002-second.md" in result.output
+        assert "Duplicate ID 'adr-001'" in result.output
 
 
 class TestMainCommandGroup:

--- a/tests/test_config_loading.py
+++ b/tests/test_config_loading.py
@@ -497,6 +497,110 @@ doc_uuid: 11111111-1111-4111-8111-111111111111
             assert "draft-about-capacity.md" in names
             assert not any("Invalid" in err for err in validator.errors)
 
+    def test_custom_naming_standard_does_not_force_numeric_id_from_filename(self):
+        """ID checks should not assume type-NNN filenames for custom naming lanes."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo_root = Path(tmpdir)
+            decisions_dir = repo_root / "docs" / "decisions"
+            decisions_dir.mkdir(parents=True)
+
+            (decisions_dir / "choose-login-architecture.md").write_text(
+                """---
+title: Choose Login Architecture
+status: Accepted
+created: 2025-01-01
+deciders: Core Team
+tags: [architecture]
+id: adr-001
+project_id: custom-naming
+doc_uuid: 12345678-1234-4123-8123-123456789abc
+---
+
+# Decision
+"""
+            )
+
+            config_data = {
+                "project": {
+                    "id": "custom-naming",
+                    "name": "Custom Naming",
+                },
+                "structure": {
+                    "docs_roots": ["docs"],
+                    "doc_types": {
+                        "adr": {
+                            "schema": "adr",
+                            "folders": ["decisions"],
+                            "naming_standard": "kebab-case",
+                            "enforce_filename_pattern": True,
+                        }
+                    },
+                },
+            }
+
+            config_path = repo_root / "docs-project.yaml"
+            with config_path.open("w") as f:
+                yaml.dump(config_data, f)
+
+            validator = DocValidator(repo_root, verbose=False)
+            validator.scan_documents()
+            validator.check_ids()
+
+            assert [doc.file_path.name for doc in validator.documents] == ["choose-login-architecture.md"]
+            assert validator.errors == []
+            assert validator.documents[0].errors == []
+
+    def test_numbered_filename_pattern_still_checks_frontmatter_id(self):
+        """Configured numeric filename patterns should still enforce matching IDs."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo_root = Path(tmpdir)
+            adr_dir = repo_root / "docs" / "adr"
+            adr_dir.mkdir(parents=True)
+
+            (adr_dir / "adr-002-test.md").write_text(
+                """---
+title: Test ADR Decision
+status: Accepted
+created: 2025-01-01
+deciders: Core Team
+tags: [architecture]
+id: adr-001
+project_id: custom-naming
+doc_uuid: 12345678-1234-4123-8123-123456789abc
+---
+
+# Decision
+"""
+            )
+
+            config_data = {
+                "project": {
+                    "id": "custom-naming",
+                    "name": "Custom Naming",
+                },
+                "structure": {
+                    "docs_roots": ["docs"],
+                    "doc_types": {
+                        "adr": {
+                            "schema": "adr",
+                            "folders": ["adr"],
+                            "filename_pattern": r"^(adr)-(\d{3})-(.+)\.md$",
+                            "enforce_filename_pattern": True,
+                        }
+                    },
+                },
+            }
+
+            config_path = repo_root / "docs-project.yaml"
+            with config_path.open("w") as f:
+                yaml.dump(config_data, f)
+
+            validator = DocValidator(repo_root, verbose=False)
+            validator.scan_documents()
+            validator.check_ids()
+
+            assert any("filename suggests 'adr-002'" in error for error in validator.documents[0].errors)
+
     def test_generic_doc_types_can_allow_plain_markdown_without_frontmatter(self):
         """Generic lanes can opt into plain markdown without YAML frontmatter."""
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/tests/test_frontmatter_comprehensive.py
+++ b/tests/test_frontmatter_comprehensive.py
@@ -365,11 +365,10 @@ id: adr-001
         changed, msg = add_missing_frontmatter(doc)
         assert changed
         post = frontmatter.loads(doc.read_text())
-        # Should generate UUID-based fallback ID (format: doc_type-uuid)
+        # Should generate a schema-valid fallback ID.
         doc_id = post.metadata["id"]
         assert isinstance(doc_id, str)
-        assert doc_id.startswith("adr-")
-        assert len(doc_id) == 12  # "adr-" + 8 hex chars
+        assert doc_id == "adr-001"
 
     def test_filename_with_special_characters(self, tmp_path):
         """Test filename with special characters."""

--- a/tests/test_frontmatter_fixes.py
+++ b/tests/test_frontmatter_fixes.py
@@ -15,6 +15,7 @@ from docuchango.fixes.frontmatter import (
     get_doc_type,
 )
 from docuchango.fixes.yaml_utils import dumps as frontmatter_dumps
+from docuchango.schemas import ADRFrontmatter, MemoFrontmatter, PRDFrontmatter, RFCFrontmatter
 
 
 class TestGetDocType:
@@ -73,8 +74,8 @@ date: 2025-01-26
         post = frontmatter.loads(doc.read_text())
         assert post.metadata["status"] == "Proposed"
 
-    def test_fix_pending_to_in_review_rfc(self, tmp_path):
-        """Test fixing 'pending' to 'In Review' for RFC."""
+    def test_fix_pending_to_proposed_rfc(self, tmp_path):
+        """Test fixing 'pending' to schema-valid 'Proposed' for RFC."""
         doc = tmp_path / "rfcs" / "rfc-001-test.md"
         doc.parent.mkdir(parents=True)
 
@@ -91,10 +92,10 @@ date: 2025-01-26
 
         changed, msg = fix_status_value(doc)
         assert changed
-        assert "In Review" in msg
+        assert "Proposed" in msg
 
         post = frontmatter.loads(doc.read_text())
-        assert post.metadata["status"] == "In Review"
+        assert post.metadata["status"] == "Proposed"
 
     def test_already_valid_status(self, tmp_path):
         """Test that valid status is not changed."""
@@ -293,8 +294,11 @@ This is the content.
         assert isinstance(title, str)
         assert "Python" in title
         assert post.metadata["status"] == "Proposed"
+        assert "created" in post.metadata
+        assert "date" not in post.metadata
         assert "deciders" in post.metadata
         assert "doc_uuid" in post.metadata
+        ADRFrontmatter(**post.metadata)
 
     def test_add_frontmatter_rfc(self, tmp_path):
         """Test adding frontmatter to RFC."""
@@ -314,7 +318,50 @@ Content here.
         post = frontmatter.loads(doc.read_text())
         assert post.metadata["id"] == "rfc-042"
         assert post.metadata["status"] == "Draft"
+        assert "author" in post.metadata
+        assert "created" in post.metadata
+        assert "date" not in post.metadata
         assert "deciders" not in post.metadata  # RFC shouldn't have deciders
+        RFCFrontmatter(**post.metadata)
+
+    def test_add_frontmatter_memo_matches_schema(self, tmp_path):
+        """Test generated Memo frontmatter validates against schema."""
+        doc = tmp_path / "memos" / "memo-007-implementation-notes.md"
+        doc.parent.mkdir(parents=True)
+
+        doc.write_text("# Implementation Notes\n\nContent here.\n")
+
+        changed, msg = add_missing_frontmatter(doc)
+        assert changed
+        assert "memo-007" in msg
+
+        post = frontmatter.loads(doc.read_text())
+        assert post.metadata["id"] == "memo-007"
+        assert "author" in post.metadata
+        assert "status" not in post.metadata
+        assert "created" in post.metadata
+        assert "date" not in post.metadata
+        MemoFrontmatter(**post.metadata)
+
+    def test_add_frontmatter_prd_matches_schema(self, tmp_path):
+        """Test generated PRD frontmatter validates against schema."""
+        doc = tmp_path / "prd" / "prd-003-user-authentication.md"
+        doc.parent.mkdir(parents=True)
+
+        doc.write_text("# User Authentication\n\nContent here.\n")
+
+        changed, msg = add_missing_frontmatter(doc)
+        assert changed
+        assert "prd-003" in msg
+
+        post = frontmatter.loads(doc.read_text())
+        assert post.metadata["id"] == "prd-003"
+        assert post.metadata["status"] == "Draft"
+        assert "author" in post.metadata
+        assert "target_release" in post.metadata
+        assert "created" in post.metadata
+        assert "date" not in post.metadata
+        PRDFrontmatter(**post.metadata)
 
     def test_frontmatter_already_exists(self, tmp_path):
         """Test that existing frontmatter is not overwritten."""

--- a/tests/test_id_compression.py
+++ b/tests/test_id_compression.py
@@ -1,5 +1,6 @@
 """Tests for document ID compression."""
 
+import pytest
 from click.testing import CliRunner
 
 from docuchango.cli import main
@@ -121,6 +122,29 @@ def test_compress_document_ids_dry_run_does_not_modify_files(tmp_path):
     assert not (memos_dir / "memo-002-second.md").exists()
     assert memo_010.read_text(encoding="utf-8") == original
     assert result.stale_references == []
+
+
+def test_compress_document_ids_collision_does_not_rewrite_references(tmp_path):
+    memos_dir = tmp_path / "memos"
+    memos_dir.mkdir()
+
+    memo_002 = memos_dir / "memo-002-second.md"
+    collision = memos_dir / "memo-001-second.md"
+    _write_memo(memo_002, "memo-002", "Second Memo")
+    collision.write_text("existing destination", encoding="utf-8")
+
+    notes = tmp_path / "notes.md"
+    notes.write_text("See memo-002 and memos/memo-002-second.md.", encoding="utf-8")
+    original_notes = notes.read_text(encoding="utf-8")
+    original_doc = memo_002.read_text(encoding="utf-8")
+
+    with pytest.raises(FileExistsError):
+        compress_document_ids(tmp_path, [memo_002], doc_type="memo")
+
+    assert memo_002.exists()
+    assert collision.read_text(encoding="utf-8") == "existing destination"
+    assert memo_002.read_text(encoding="utf-8") == original_doc
+    assert notes.read_text(encoding="utf-8") == original_notes
 
 
 def test_audit_missing_document_references_reports_stale_refs(tmp_path):

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -180,3 +180,39 @@ More content.
             e for e in all_errors if "Closing code fence has extra text" in e and "appears to be" not in e
         ]
         assert len(confusing_errors) == 0, f"Should not have confusing closing fence errors. Found: {confusing_errors}"
+
+    def test_prd_duplicate_uuid_is_reported(self, tmp_path):
+        """PRDs require doc_uuid, so duplicate PRD UUIDs must be reported."""
+        docs_root = tmp_path / "repo"
+        prd_dir = docs_root / "docs-cms" / "prd"
+        prd_dir.mkdir(parents=True)
+
+        duplicate_uuid = "12345678-1234-4123-8123-123456789abc"
+        for number, title in [(1, "First Product Requirement"), (2, "Second Product Requirement")]:
+            (prd_dir / f"prd-{number:03d}-test.md").write_text(
+                f"""---
+id: prd-{number:03d}
+title: {title}
+status: Draft
+author: Product Team
+created: 2025-01-0{number}
+target_release: TBD
+tags: []
+project_id: test-project
+doc_uuid: {duplicate_uuid}
+---
+
+# {title}
+""",
+                encoding="utf-8",
+            )
+
+        validator = DocValidator(repo_root=docs_root, verbose=False)
+        validator.scan_documents()
+        validator.check_uuids()
+
+        all_errors = []
+        for doc in validator.documents:
+            all_errors.extend(doc.errors)
+
+        assert any("Duplicate UUID" in error and duplicate_uuid in error for error in all_errors)


### PR DESCRIPTION
## Summary
- run the full validator pipeline from the CLI validate command
- align frontmatter repair defaults with schemas
- make ID compression preflight rename collisions before rewriting references
- include PRDs in UUID uniqueness validation
- make ID validation respect custom naming lanes
- batch frontmatter metadata fixes into one parse/write pass

## Tests
- uv run ruff check .
- uv run mypy docuchango tests
- uv run pytest

Stack base: chore/remove-legacy-python39