### PR TITLE
chore: tighten fixer type coverage

### DIFF
--- a/docuchango/fixes/frontmatter.py
+++ b/docuchango/fixes/frontmatter.py
@@ -10,6 +10,7 @@ import re
 import uuid
 from datetime import date, datetime
 from pathlib import Path
+from typing import Any
 
 import frontmatter
 
@@ -375,7 +376,7 @@ def fix_all_frontmatter(file_path: Path, dry_run: bool = False) -> list[str]:
     return messages
 
 
-def _fix_status_metadata(metadata: dict, doc_type: str | None) -> str | None:
+def _fix_status_metadata(metadata: dict[str, Any], doc_type: str | None) -> str | None:
     """Normalize status in already-parsed metadata."""
     if "status" not in metadata:
         return None
@@ -405,7 +406,7 @@ def _fix_status_metadata(metadata: dict, doc_type: str | None) -> str | None:
     return None
 
 
-def _fix_date_metadata(metadata: dict, content: str) -> str | None:
+def _fix_date_metadata(metadata: dict[str, Any], content: str) -> str | None:
     """Normalize date or created in already-parsed metadata."""
     if "date" in metadata:
         date_field = "date"
@@ -461,7 +462,7 @@ def _fix_date_metadata(metadata: dict, content: str) -> str | None:
     return None
 
 
-def _fix_tags_metadata(metadata: dict) -> list[str]:
+def _fix_tags_metadata(metadata: dict[str, Any]) -> list[str]:
     """Normalize tags in already-parsed metadata."""
     messages = []
     if "tags" not in metadata:

--- a/docuchango/fixes/id_compression.py
+++ b/docuchango/fixes/id_compression.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import re
+from collections.abc import Iterator
 from dataclasses import dataclass, field
 from pathlib import Path
 
@@ -302,8 +303,9 @@ def _document_id_for_file(file_path: Path) -> str | None:
         post = frontmatter.load(file_path)
     except Exception:
         post = None
-    if post and isinstance(post.metadata.get("id"), str):
-        metadata_id = post.metadata["id"].lower()
+    metadata_value = post.metadata.get("id") if post else None
+    if isinstance(metadata_value, str):
+        metadata_id = metadata_value.lower()
         if DOC_ID_RE.fullmatch(metadata_id):
             return metadata_id
 
@@ -324,7 +326,7 @@ def _set_frontmatter_id(file_path: Path, doc_id: str) -> None:
     file_path.write_text(frontmatter_dumps(post), encoding="utf-8")
 
 
-def _iter_text_files(repo_root: Path):  # type: ignore[no-untyped-def]
+def _iter_text_files(repo_root: Path) -> Iterator[Path]:
     for path in repo_root.rglob("*"):
         if any(part in SKIP_DIRS for part in path.parts):
             continue

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -213,7 +213,7 @@ disallow_untyped_decorators = true
 no_implicit_optional = true
 # Exclude non-core modules from strict checking
 exclude = [
-    "docuchango/fixes/.*",
+    "docuchango/fixes/(bulk_update|code_blocks|cross_plugin_links|doc_links|docs|internal_links|mdx_syntax|tags|timestamps|whitespace|yaml_utils)\\.py",
     "test_install\\.py",
 ]
 


### PR DESCRIPTION
## Summary
- bring frontmatter and ID compression fixers under mypy coverage
- narrow the broad fixes mypy exclusion to remaining legacy fixer modules
- add small typing fixes for metadata helpers and text file iteration

## Tests
- uv run ruff check .
- uv run mypy docuchango tests
- uv run pytest

Stack base: #60